### PR TITLE
Remove search bar and recent activity from home page

### DIFF
--- a/templates/home_page.hbs
+++ b/templates/home_page.hbs
@@ -1,17 +1,6 @@
 <h1 class="visibility-hidden">{{ help_center.name }}</h1>
 
-<section id="main-content" class="section hero">
-  <div class="hero-inner">
-    <h2 class="visibility-hidden">{{ t 'search' }}</h2>
-    <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12" class="search-icon" aria-hidden="true">
-      <circle cx="4.5" cy="4.5" r="4" fill="none" stroke="currentColor"/>
-      <path stroke="currentColor" stroke-linecap="round" d="M11 11L7.5 7.5"/>
-    </svg>
-    {{search submit=false instant=settings.instant_search class='search search-full'}}
-  </div>
-</section>
-
-<div class="container intranet-grid">
+<div id="main-content" class="container intranet-grid">
 <div class="container">
   <section id="company-carousel" class="carousel section">
     <div class="carousel-item active">Welcome slide</div>
@@ -105,9 +94,5 @@
     </section>
   {{/if}}
 
-  <section class="section home-section activity">
-    {{#if settings.show_recent_activity}}
-      {{recent_activity}}
-    {{/if}}
-  </section>
+</div>
 </div>


### PR DESCRIPTION
## Summary
- remove home page search bar
- drop recent activity section

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68b5a890a4b88320bd4550b660359ced