### PR TITLE
feat: add announcements carousel

### DIFF
--- a/script.js
+++ b/script.js
@@ -658,8 +658,14 @@
     }
   });
 
-  function initCarousel() {
-    const slides = document.querySelectorAll('#company-carousel .carousel-item');
+  function initCarousel(selector, limit = Infinity) {
+    const container = document.querySelector(selector);
+    if (!container) return;
+    let slides = Array.from(container.querySelectorAll('.carousel-item'));
+    if (limit !== Infinity) {
+      slides.slice(limit).forEach((slide) => slide.remove());
+      slides = slides.slice(0, limit);
+    }
     let index = 0;
     if (slides.length) {
       slides[0].classList.add('active');
@@ -671,6 +677,36 @@
     }
   }
 
-  document.addEventListener('DOMContentLoaded', initCarousel);
+  async function loadAnnouncementImages() {
+    const slides = document.querySelectorAll('#announcements-carousel .carousel-item');
+    for (const slide of slides) {
+      const id = slide.dataset.articleId;
+      if (!id) continue;
+      try {
+        const response = await fetch(`/api/v2/help_center/articles/${id}.json`);
+        const data = await response.json();
+        const match = data.article.body.match(/<img[^>]+src="([^"]+)"/i);
+        if (match) {
+          const img = slide.querySelector('img');
+          if (img) {
+            img.src = match[1];
+          }
+        }
+      } catch (e) {
+        // ignore errors
+      }
+    }
+  }
+
+  function init() {
+    initCarousel('#company-carousel');
+    const announcementCarousel = document.querySelector('#announcements-carousel');
+    if (announcementCarousel) {
+      initCarousel('#announcements-carousel', 3);
+      loadAnnouncementImages();
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', init);
 
 })();

--- a/src/carousel.js
+++ b/src/carousel.js
@@ -1,5 +1,11 @@
-export function initCarousel() {
-  const slides = document.querySelectorAll('#company-carousel .carousel-item');
+export function initCarousel(selector, limit = Infinity) {
+  const container = document.querySelector(selector);
+  if (!container) return;
+  let slides = Array.from(container.querySelectorAll('.carousel-item'));
+  if (limit !== Infinity) {
+    slides.slice(limit).forEach((slide) => slide.remove());
+    slides = slides.slice(0, limit);
+  }
   let index = 0;
   if (slides.length) {
     slides[0].classList.add('active');
@@ -11,4 +17,34 @@ export function initCarousel() {
   }
 }
 
-document.addEventListener('DOMContentLoaded', initCarousel);
+async function loadAnnouncementImages() {
+  const slides = document.querySelectorAll('#announcements-carousel .carousel-item');
+  for (const slide of slides) {
+    const id = slide.dataset.articleId;
+    if (!id) continue;
+    try {
+      const response = await fetch(`/api/v2/help_center/articles/${id}.json`);
+      const data = await response.json();
+      const match = data.article.body.match(/<img[^>]+src="([^"]+)"/i);
+      if (match) {
+        const img = slide.querySelector('img');
+        if (img) {
+          img.src = match[1];
+        }
+      }
+    } catch (e) {
+      // ignore errors
+    }
+  }
+}
+
+function init() {
+  initCarousel('#company-carousel');
+  const announcementCarousel = document.querySelector('#announcements-carousel');
+  if (announcementCarousel) {
+    initCarousel('#announcements-carousel', 3);
+    loadAnnouncementImages();
+  }
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/style.css
+++ b/style.css
@@ -1329,6 +1329,7 @@ ul {
 /***** Carousel and introduction *****/
 #company-carousel {
   grid-area: carousel;
+}
 
 /***** Carousel and introduction *****/
 #company-carousel {
@@ -1379,6 +1380,21 @@ ul {
 
 .announcements {
   grid-area: announcements;
+}
+
+#announcements-carousel {
+  text-align: center;
+}
+#announcements-carousel .carousel-item {
+  display: none;
+}
+#announcements-carousel .carousel-item.active {
+  display: block;
+}
+#announcements-carousel img {
+  max-width: 100%;
+  height: auto;
+  margin-bottom: 10px;
 }
 
 .community {

--- a/styles/_home-page.scss
+++ b/styles/_home-page.scss
@@ -35,6 +35,8 @@
 
 #company-carousel {
   grid-area: carousel;
+}
+
 /***** Carousel and introduction *****/
 
 #company-carousel {
@@ -87,6 +89,24 @@
 .departments { grid-area: departments; }
 
 .announcements { grid-area: announcements; }
+
+#announcements-carousel {
+  text-align: center;
+
+  .carousel-item {
+    display: none;
+  }
+
+  .carousel-item.active {
+    display: block;
+  }
+
+  img {
+    max-width: 100%;
+    height: auto;
+    margin-bottom: 10px;
+  }
+}
 
 .community { grid-area: community; }
 

--- a/templates/home_page.hbs
+++ b/templates/home_page.hbs
@@ -67,30 +67,22 @@
   {{#if promoted_articles}}
     <section class="section announcements">
       <h2>Announcements</h2>
-      <ul class="article-list promoted-articles">
+      <div id="announcements-carousel" class="carousel">
         {{#each promoted_articles}}
-          <li class="promoted-articles-item">
-              <a href="{{url}}">
-                {{title}}
-    {{#if promoted_articles}}
-      <section class="articles announcements">
-        <h2>Announcements</h2>
-        <ul class="article-list promoted-articles">
-          {{#each promoted_articles}}
-            <li class="promoted-articles-item">
-                <a href="{{url}}">
-                  {{title}}
-
-                {{#if internal}}
-                  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16" class="icon-lock" title="{{t 'internal'}}">
-                    <rect width="12" height="9" x="2" y="7" fill="currentColor" rx="1" ry="1"/>
-                    <path fill="none" stroke="currentColor" d="M4.5 7.5V4a3.5 3.5 0 017 0v3.5"/>
-                  </svg>
-                {{/if}}
-              </a>
-          </li>
+          <div class="carousel-item" data-article-id="{{id}}">
+            <a href="{{url}}">
+              <img alt="{{title}}" />
+              <span>{{title}}</span>
+              {{#if internal}}
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16" class="icon-lock" title="{{t 'internal'}}">
+                  <rect width="12" height="9" x="2" y="7" fill="currentColor" rx="1" ry="1"/>
+                  <path fill="none" stroke="currentColor" d="M4.5 7.5V4a3.5 3.5 0 017 0v3.5"/>
+                </svg>
+              {{/if}}
+            </a>
+          </div>
         {{/each}}
-      </ul>
+      </div>
     </section>
   {{/if}}
 


### PR DESCRIPTION
## Summary
- display Announcements as an auto-rotating carousel showing the latest three articles with images
- load first image for each announcement via Help Center API
- style the Announcements carousel

## Testing
- `yarn build`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68b5a9a0928483209e87cf04eb53123d