### PR TITLE
feat: add announcements and departments to homepage

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -292,6 +292,13 @@
           "description": "recent_activity_description",
           "label": "recent_activity_label",
           "value": true
+        },
+        {
+          "identifier": "departments",
+          "type": "text",
+          "description": "departments_description",
+          "label": "departments_label",
+          "value": "[]"
         }
       ]
     },

--- a/script.js
+++ b/script.js
@@ -671,6 +671,28 @@
     }
   }
 
+  function renderDepartments() {
+    const dataEl = document.getElementById('departments-data');
+    if (!dataEl) return;
+    try {
+      const departments = JSON.parse(dataEl.textContent);
+      const list = document.querySelector('.departments .blocks-list');
+      if (list && Array.isArray(departments)) {
+        departments.forEach((dep) => {
+          if (dep && dep.name && dep.url) {
+            const li = document.createElement('li');
+            li.className = 'blocks-item';
+            li.innerHTML = `<a href="${dep.url}" class="blocks-item-link"><span class="blocks-item-title">${dep.name}</span></a>`;
+            list.appendChild(li);
+          }
+        });
+      }
+    } catch (e) {
+      console.error('Invalid departments data', e);
+    }
+  }
+
   document.addEventListener('DOMContentLoaded', initCarousel);
+  document.addEventListener('DOMContentLoaded', renderDepartments);
 
 })();

--- a/templates/home_page.hbs
+++ b/templates/home_page.hbs
@@ -25,62 +25,33 @@
 
   <section class="section departments">
     <h2>Departments</h2>
-    <section class="categories blocks">
-      <ul class="blocks-list">
-        {{#each categories}}
-          {{#if ../has_multiple_categories}}
-            <li class="blocks-item">
-              <a href='{{url}}' class="blocks-item-link">
-                <span class="blocks-item-title">{{name}}</span>
-                <span class="blocks-item-description">{{excerpt description}}</span>
-              </a>
-            </li>
-          {{else}}
-            {{#each sections}}
-              <li class="blocks-item">
-                <a href='{{url}}' class="blocks-item-link">
-                  <span class="blocks-item-title">
-                    {{name}}
-                  </span>
-                  <span class="blocks-item-description">{{excerpt description}}</span>
-                </a>
-              </li>
-            {{/each}}
-          {{/if}}
-        {{/each}}
-      </ul>
-      {{pagination}}
+    <section class="blocks">
+      <ul class="blocks-list"></ul>
     </section>
+    <script id="departments-data" type="application/json">
+      {{{settings.departments}}}
+    </script>
   </section>
 
   {{#if promoted_articles}}
-    <section class="section announcements">
-      <h2>Announcements</h2>
-      <ul class="article-list promoted-articles">
-        {{#each promoted_articles}}
-          <li class="promoted-articles-item">
-              <a href="{{url}}">
-                {{title}}
-    {{#if promoted_articles}}
-      <section class="articles announcements">
-        <h2>Announcements</h2>
-        <ul class="article-list promoted-articles">
-          {{#each promoted_articles}}
-            <li class="promoted-articles-item">
-                <a href="{{url}}">
-                  {{title}}
-
-                {{#if internal}}
-                  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16" class="icon-lock" title="{{t 'internal'}}">
-                    <rect width="12" height="9" x="2" y="7" fill="currentColor" rx="1" ry="1"/>
-                    <path fill="none" stroke="currentColor" d="M4.5 7.5V4a3.5 3.5 0 017 0v3.5"/>
-                  </svg>
-                {{/if}}
-              </a>
-          </li>
-        {{/each}}
-      </ul>
-    </section>
+  <section class="section announcements">
+    <h2>Announcements</h2>
+    <ul class="article-list promoted-articles">
+      {{#each promoted_articles}}
+        <li class="promoted-articles-item">
+          <a href="{{url}}">
+            {{title}}
+            {{#if internal}}
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16" class="icon-lock" title="{{t 'internal'}}">
+                <rect width="12" height="9" x="2" y="7" fill="currentColor" rx="1" ry="1"/>
+                <path fill="none" stroke="currentColor" d="M4.5 7.5V4a3.5 3.5 0 017 0v3.5"/>
+              </svg>
+            {{/if}}
+          </a>
+        </li>
+      {{/each}}
+    </ul>
+  </section>
   {{/if}}
 
   {{#if help_center.community_enabled}}

--- a/translations/en-us.json
+++ b/translations/en-us.json
@@ -22,6 +22,8 @@
   "community_image_label": "Community banner",
   "community_post_group_label": "Community post elements",
   "community_topic_group_label": "Community topic elements",
+  "departments_description": "JSON array of departments to display on home page",
+  "departments_label": "Departments",
   "favicon_description": "Icon displayed in the address bar of your browser",
   "favicon_label": "Favicon",
   "follow_article_description": "Users can follow a specific article",


### PR DESCRIPTION
## Summary
- replace category list with customizable departments cards
- add announcements section rendering promoted articles
- expose `departments` setting for home page configuration

## Testing
- `CI=true yarn test`
- `yarn eslint` *(fails: 5 errors, 11 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b5aaf72f1c8320a06542ab98aa484c