### PR TITLE
refactor: remove unused community section

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -248,12 +248,6 @@
           "type": "file",
           "description": "community_background_image_description",
           "label": "community_background_image_label"
-        },
-        {
-          "identifier": "community_image",
-          "type": "file",
-          "description": "community_image_description",
-          "label": "community_image_label"
         }
       ]
     },

--- a/style.css
+++ b/style.css
@@ -1322,7 +1322,7 @@ ul {
 @media (min-width: 1024px) {
   .intranet-grid {
     grid-template-columns: 2fr 1fr;
-    grid-template-areas: "carousel carousel" "introduction quick-links" "departments announcements" "community community" "activity activity";
+    grid-template-areas: "carousel carousel" "introduction quick-links" "departments announcements" "activity activity";
   }
 }
 
@@ -1397,10 +1397,6 @@ ul {
   margin-bottom: 10px;
 }
 
-.community {
-  grid-area: community;
-}
-
 .activity {
   grid-area: activity;
 }
@@ -1450,30 +1446,6 @@ ul {
   }
 }
 
-/***** Community section in homepage *****/
-.community {
-  text-align: center;
-}
-.community-image {
-  min-height: 300px;
-  margin-top: 32px;
-  background-image: url($community_image);
-  background-position: center;
-  background-repeat: no-repeat;
-  max-width: 100%;
-}
-.community a {
-  color: $link_color;
-  text-decoration: underline;
-}
-.community a:visited {
-  color: $visited_link_color;
-}
-.community a:hover, .community a:active, .community a:focus {
-  color: $hover_link_color;
-}
-
-.community,
 .activity {
   border-top: 1px solid #ddd;
   padding: 30px 0;

--- a/styles/_home-page.scss
+++ b/styles/_home-page.scss
@@ -26,7 +26,6 @@
       "carousel carousel"
       "introduction quick-links"
       "departments announcements"
-      "community community"
       "activity activity";
   }
 }
@@ -108,8 +107,6 @@
   }
 }
 
-.community { grid-area: community; }
-
 .activity { grid-area: activity; }
 
 /***** Promoted articles *****/
@@ -157,23 +154,7 @@
 
 }
 
-/***** Community section in homepage *****/
-.community {
-  text-align: center;
 
-  &-image {
-    min-height: 300px;
-    margin-top: 32px;
-    background-image: url($community_image);
-    background-position: center;
-    background-repeat: no-repeat;
-    max-width: 100%;
-  }
-
-  @include standalone-link;
-}
-
-.community,
 .activity {
   border-top: 1px solid $low-contrast-border-color;
   padding: 30px 0;

--- a/templates/home_page.hbs
+++ b/templates/home_page.hbs
@@ -75,16 +75,5 @@
     </section>
   {{/if}}
 
-  {{#if help_center.community_enabled}}
-    <section class="section home-section community">
-      <h2>{{t 'community'}}</h2>
-      {{#link 'community' class='community-link'}}
-        {{t 'join_conversation'}}
-      {{/link}}
-
-      <div class="community-image"></div>
-    </section>
-  {{/if}}
-
 </div>
 </div>

--- a/translations.yml
+++ b/translations.yml
@@ -163,16 +163,6 @@ parts:
       screenshot: "https://zendesk.box.com/s/9kigi6qd5ufgskmqtefk0cfpgrmxn78y"
       value: "Community hero image"
   - translation:
-      key: "txt.help_center_copenhagen_theme.community_image_description"
-      title: "Description for the community image setting"
-      screenshot: "https://zendesk.box.com/s/9kigi6qd5ufgskmqtefk0cfpgrmxn78y"
-      value: "Image for the community section on the home page"
-  - translation:
-      key: "txt.help_center_copenhagen_theme.community_image_label"
-      title: "Label for the community image setting"
-      screenshot: "https://zendesk.box.com/s/9kigi6qd5ufgskmqtefk0cfpgrmxn78y"
-      value: "Community banner"
-  - translation:
       key: "txt.help_center_copenhagen_theme.search_group_label"
       title: "Label for the search settings group"
       screenshot: "https://drive.google.com/open?id=1uZaNe12E-A_snTd_7AjcqirB4ROLF4bB"

--- a/translations/ar.json
+++ b/translations/ar.json
@@ -18,8 +18,6 @@
   "colors_group_label": "الألوان",
   "community_background_image_description": "صورة الخلفية الرئيسية لصفحة مواضيع المجتمع",
   "community_background_image_label": "صورة الخلفية الرئيسية للمجتمع",
-  "community_image_description": "صورة لقسم المجتمع على الصفحة الرئيسية",
-  "community_image_label": "شريط المجتمع",
   "community_post_group_label": "عناصر منشورات المجتمع",
   "community_topic_group_label": "عناصر مواضيع المجتمع",
   "favicon_description": "أيقونة تظهر في شريط عناوين المتصفح",

--- a/translations/bg.json
+++ b/translations/bg.json
@@ -18,8 +18,6 @@
   "colors_group_label": "Цветове",
   "community_background_image_description": "Главно изображение на страницата с теми на общността",
   "community_background_image_label": "Главно изображение на общността",
-  "community_image_description": "Изображение за раздела за общността на началната страница",
-  "community_image_label": "Банер за общността",
   "community_post_group_label": "Елементи на постингите в общността",
   "community_topic_group_label": "Елементи на темите в общността",
   "favicon_description": "Икона в адресната лента на браузъра",

--- a/translations/cs.json
+++ b/translations/cs.json
@@ -18,8 +18,6 @@
   "colors_group_label": "Barvy",
   "community_background_image_description": "Obrázek na pozadí stránky témat komunity",
   "community_background_image_label": "Obrázek pozadí komunity",
-  "community_image_description": "Obrázek pro oddíl komunity na domovské stránce",
-  "community_image_label": "Proužek komunity",
   "community_post_group_label": "Elementy příspěvku komunity",
   "community_topic_group_label": "Elementy tématu komunity",
   "favicon_description": "Ikona zobrazená v řádku adresy prohlížeče",

--- a/translations/da.json
+++ b/translations/da.json
@@ -18,8 +18,6 @@
   "colors_group_label": "Farver",
   "community_background_image_description": "Baggrundsbillede på emneside for community",
   "community_background_image_label": "Baggrundsbillede for community",
-  "community_image_description": "Billede til community-sektion på startside",
-  "community_image_label": "Community-banner",
   "community_post_group_label": "Community-opslagselementer",
   "community_topic_group_label": "Community-emneelementer",
   "favicon_description": "Ikon vist på adresselinjen i din browser",

--- a/translations/de.json
+++ b/translations/de.json
@@ -18,8 +18,6 @@
   "colors_group_label": "Farben",
   "community_background_image_description": "Hero-Bild auf der Community-Themenseite",
   "community_background_image_label": "Hero-Bild für die Community",
-  "community_image_description": "Bild für den Community-Abschnitt auf der Homepage",
-  "community_image_label": "Community-Banner",
   "community_post_group_label": "Elemente in Community-Posts",
   "community_topic_group_label": "Elemente in Community-Themen",
   "favicon_description": "Symbol in der Adressleiste des Browsers",

--- a/translations/el.json
+++ b/translations/el.json
@@ -18,8 +18,6 @@
   "colors_group_label": "Χρώματα",
   "community_background_image_description": "Εικόνα hero στη σελίδα θεμάτων κοινότητας",
   "community_background_image_label": "Εικόνα hero κοινότητας",
-  "community_image_description": "Εικόνα για την ενότητα κοινότητας στην αρχική σελίδα",
-  "community_image_label": "Banner κοινότητας",
   "community_post_group_label": "Στοιχεία αναρτήσεων κοινότητας",
   "community_topic_group_label": "Στοιχεία θεμάτων κοινότητας",
   "favicon_description": "Εικονίδιο που εμφανίζεται στη γραμμή διεύθυνσης του προγράμματος περιήγησης",

--- a/translations/en-ca.json
+++ b/translations/en-ca.json
@@ -18,8 +18,6 @@
   "colors_group_label": "Colours",
   "community_background_image_description": "Hero image on the community topics page",
   "community_background_image_label": "Community hero image",
-  "community_image_description": "Image for the community section on the home page",
-  "community_image_label": "Community banner",
   "community_post_group_label": "Community post elements",
   "community_topic_group_label": "Community topic elements",
   "favicon_description": "Icon displayed in the address bar of your browser",

--- a/translations/en-gb.json
+++ b/translations/en-gb.json
@@ -18,8 +18,6 @@
   "colors_group_label": "Colours",
   "community_background_image_description": "Hero image on the community topics page",
   "community_background_image_label": "Community hero image",
-  "community_image_description": "Image for the community section on the home page",
-  "community_image_label": "Community banner",
   "community_post_group_label": "Community post elements",
   "community_topic_group_label": "Community topic elements",
   "favicon_description": "Icon displayed in the address bar of your browser",

--- a/translations/en-us.json
+++ b/translations/en-us.json
@@ -18,8 +18,6 @@
   "colors_group_label": "Colors",
   "community_background_image_description": "Hero image on the community topics page",
   "community_background_image_label": "Community hero image",
-  "community_image_description": "Image for the community section on the home page",
-  "community_image_label": "Community banner",
   "community_post_group_label": "Community post elements",
   "community_topic_group_label": "Community topic elements",
   "favicon_description": "Icon displayed in the address bar of your browser",

--- a/translations/es-419.json
+++ b/translations/es-419.json
@@ -18,8 +18,6 @@
   "colors_group_label": "Colores",
   "community_background_image_description": "Imagen hero en la página de temas de la comunidad",
   "community_background_image_label": "Imagen hero de la comunidad",
-  "community_image_description": "Imagen para la sección de comunidad en la página principal",
-  "community_image_label": "Pancarta de la comunidad",
   "community_post_group_label": "Elementos de publicación de la comunidad",
   "community_topic_group_label": "Elementos de tema de la comunidad",
   "favicon_description": "Icono mostrado en la barra de dirección del navegador",

--- a/translations/es-es.json
+++ b/translations/es-es.json
@@ -18,8 +18,6 @@
   "colors_group_label": "Colores",
   "community_background_image_description": "Imagen hero en la página de temas de la comunidad",
   "community_background_image_label": "Imagen hero de la comunidad",
-  "community_image_description": "Imagen para la sección de comunidad en la página principal",
-  "community_image_label": "Pancarta de la comunidad",
   "community_post_group_label": "Elementos de publicación de la comunidad",
   "community_topic_group_label": "Elementos de tema de la comunidad",
   "favicon_description": "Icono mostrado en la barra de dirección del navegador",

--- a/translations/es.json
+++ b/translations/es.json
@@ -18,8 +18,6 @@
   "colors_group_label": "Colores",
   "community_background_image_description": "Imagen hero en la página de temas de la comunidad",
   "community_background_image_label": "Imagen hero de la comunidad",
-  "community_image_description": "Imagen para la sección de comunidad en la página principal",
-  "community_image_label": "Pancarta de la comunidad",
   "community_post_group_label": "Elementos de publicación de la comunidad",
   "community_topic_group_label": "Elementos de tema de la comunidad",
   "favicon_description": "Icono mostrado en la barra de dirección del navegador",

--- a/translations/fi.json
+++ b/translations/fi.json
@@ -18,8 +18,6 @@
   "colors_group_label": "Värit",
   "community_background_image_description": "Yhteisön aihesivun taustakuva",
   "community_background_image_label": "Yhteisön taustakuva",
-  "community_image_description": "Kotisivun yhteisöosan kuva",
-  "community_image_label": "Yhteisön mainospalkki",
   "community_post_group_label": "Yhteisöviestielementit",
   "community_topic_group_label": "Yhteisöaihe-elementit",
   "favicon_description": "Selaimen osoitepalkissa esitetty kuvake",

--- a/translations/fr-ca.json
+++ b/translations/fr-ca.json
@@ -18,8 +18,6 @@
   "colors_group_label": "Couleurs",
   "community_background_image_description": "Image de premier plan sur la page des sujets de la communauté",
   "community_background_image_label": "Image de premier plan pour la communauté",
-  "community_image_description": "Image pour la section Communauté de la page d’accueil",
-  "community_image_label": "Bannière Communauté",
   "community_post_group_label": "Éléments des publications dans la communauté",
   "community_topic_group_label": "Éléments des sujets de la communauté",
   "favicon_description": "Icône affichée dans la barre d’adresse de votre navigateur",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -18,8 +18,6 @@
   "colors_group_label": "Couleurs",
   "community_background_image_description": "Hero image sur la page des sujets de la communauté",
   "community_background_image_label": "Hero image pour la communauté",
-  "community_image_description": "Image pour la section Communauté de la page d’accueil",
-  "community_image_label": "Bannière Communauté",
   "community_post_group_label": "Éléments des publications dans la communauté",
   "community_topic_group_label": "Éléments des sujets de la communauté",
   "favicon_description": "Icône affichée dans la barre d’adresse de votre navigateur",

--- a/translations/he.json
+++ b/translations/he.json
@@ -18,8 +18,6 @@
   "colors_group_label": "צבעים",
   "community_background_image_description": "התמונה הראשית (hero image) בדף הנושאים של הקהילה",
   "community_background_image_label": "תמונה ראשית לקהילה",
-  "community_image_description": "תמונה בשביל חלק הקהילה בדף הבית",
-  "community_image_label": "באנר הקהילה",
   "community_post_group_label": "רכיבי פוסט בקהילה​",
   "community_topic_group_label": "רכיבי נושא בקהילה",
   "favicon_description": "אייקון המוצג בשורת הכתובת בדפדפן",

--- a/translations/hi.json
+++ b/translations/hi.json
@@ -18,8 +18,6 @@
   "colors_group_label": "रंग",
   "community_background_image_description": "समुदाय विषयों पृष्ठ पर हीरो छवि",
   "community_background_image_label": "समुदाय हीरो छवि",
-  "community_image_description": "होम पृष्ठ पर समुदाय अनुभाग के लिए छवि",
-  "community_image_label": "समुदाय बैनर",
   "community_post_group_label": "समुदाय पोस्ट के तत्व",
   "community_topic_group_label": "समुदाय विषय के तत्व",
   "favicon_description": "आइकन आपके ब्राउज़र के पता बार में प्रदर्शित किया जाता है",

--- a/translations/hu.json
+++ b/translations/hu.json
@@ -18,8 +18,6 @@
   "colors_group_label": "Színek",
   "community_background_image_description": "A közösségi témakörök oldalának fő képe",
   "community_background_image_label": "Közösség fő képe",
-  "community_image_description": "A kezdőlap közösségi szakaszának képe",
-  "community_image_label": "Közösségi banner",
   "community_post_group_label": "Közösségi bejegyzések elemei",
   "community_topic_group_label": "Közösségi témakör elemei",
   "favicon_description": "A böngésző címsorában megjelenített ikon",

--- a/translations/id.json
+++ b/translations/id.json
@@ -18,8 +18,6 @@
   "colors_group_label": "Warna",
   "community_background_image_description": "Gambar utama pada halaman topik komunitas",
   "community_background_image_label": "Gambar utama komunitas",
-  "community_image_description": "Gambar bagian komunitas pada halaman beranda",
-  "community_image_label": "Spanduk komunitas",
   "community_post_group_label": "Elemen posting komunitas",
   "community_topic_group_label": "Elemen topik komunitas",
   "favicon_description": "Ikon yang ditampilkan pada batang alamat browser Anda",

--- a/translations/it.json
+++ b/translations/it.json
@@ -18,8 +18,6 @@
   "colors_group_label": "Colori",
   "community_background_image_description": "Hero image della pagina degli argomenti della community",
   "community_background_image_label": "Hero image community",
-  "community_image_description": "Immagine per la sezione community della home page",
-  "community_image_label": "Banner community",
   "community_post_group_label": "Elementi post della community",
   "community_topic_group_label": "Elementi argomento della community",
   "favicon_description": "Icona visualizzata nella barra dell’indirizzo del browser",

--- a/translations/ja.json
+++ b/translations/ja.json
@@ -18,8 +18,6 @@
   "colors_group_label": "色",
   "community_background_image_description": "コミュニティのトピックページのトップイメージ",
   "community_background_image_label": "コミュニティトップイメージ",
-  "community_image_description": "ホームページのコミュニティセクションの画像",
-  "community_image_label": "コミュニティバナー",
   "community_post_group_label": "コミュニティ投稿の要素",
   "community_topic_group_label": "コミュニティトピックの要素",
   "favicon_description": "ブラウザのアドレスバーに表示するアイコン",

--- a/translations/ko.json
+++ b/translations/ko.json
@@ -18,8 +18,6 @@
   "colors_group_label": "색",
   "community_background_image_description": "커뮤니티 주제 페이지의 히어로 이미지",
   "community_background_image_label": "커뮤니티 히어로 이미지",
-  "community_image_description": "홈 페이지 커뮤니티 섹션의 이미지",
-  "community_image_label": "커뮤니티 배너",
   "community_post_group_label": "커뮤니티 게시물 요소",
   "community_topic_group_label": "커뮤니티 주제 요소",
   "favicon_description": "브라우저 주소 표시줄에 표시되는 아이콘",

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -18,8 +18,6 @@
   "colors_group_label": "Kleuren",
   "community_background_image_description": "Hero image op de community pagina met onderwerpen",
   "community_background_image_label": "Hero image Community",
-  "community_image_description": "Afbeelding voor het communitygedeelte op de startpagina",
-  "community_image_label": "Banner voor community",
   "community_post_group_label": "Elementen van communitybericht",
   "community_topic_group_label": "Elementen van communityonderwerp",
   "favicon_description": "Pictogram dat wordt weergegeven op de adresbalk van uw browser",

--- a/translations/no.json
+++ b/translations/no.json
@@ -18,8 +18,6 @@
   "colors_group_label": "Farger",
   "community_background_image_description": "Bannerbilde på siden for nettsamfunnsemner",
   "community_background_image_label": "Bannerbilde for nettsamfunn",
-  "community_image_description": "Bilde for nettsamfunnsdelen på hjemmesiden",
-  "community_image_label": "Nettsamfunnsfane",
   "community_post_group_label": "Elementer for nettsamfunninnlegg",
   "community_topic_group_label": "Elementer for nettsamfunnemner",
   "favicon_description": "Ikon som vises i adresselinjen i nettleseren",

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -18,8 +18,6 @@
   "colors_group_label": "Kolory",
   "community_background_image_description": "Obraz główny na stronie tematów społeczności",
   "community_background_image_label": "Obraz główny społeczności",
-  "community_image_description": "Obraz sekcji społeczności na stronie głównej",
-  "community_image_label": "Baner społeczności",
   "community_post_group_label": "Elementy wpisów w społeczności",
   "community_topic_group_label": "Elementy tematów w społeczności",
   "favicon_description": "Ikona wyświetlana w pasku adresu przeglądarki",

--- a/translations/pt-br.json
+++ b/translations/pt-br.json
@@ -18,8 +18,6 @@
   "colors_group_label": "Cores",
   "community_background_image_description": "Imagem principal na página de tópicos da comunidade",
   "community_background_image_label": "Imagem principal da comunidade",
-  "community_image_description": "Imagem da seção da comunidade na página inicial",
-  "community_image_label": "Banner da comunidade",
   "community_post_group_label": "Elementos da publicação da comunidade",
   "community_topic_group_label": "Elementos do tópico da comunidade",
   "favicon_description": "Ícone exibido na barra de endereços do seu navegador",

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -18,8 +18,6 @@
   "colors_group_label": "Cores",
   "community_background_image_description": "Imagem principal na página de tópicos da comunidade",
   "community_background_image_label": "Imagem principal da comunidade",
-  "community_image_description": "Imagem da seção da comunidade na página inicial",
-  "community_image_label": "Banner da comunidade",
   "community_post_group_label": "Elementos da publicação da comunidade",
   "community_topic_group_label": "Elementos do tópico da comunidade",
   "favicon_description": "Ícone exibido na barra de endereços do seu navegador",

--- a/translations/ro.json
+++ b/translations/ro.json
@@ -18,8 +18,6 @@
   "colors_group_label": "Culori",
   "community_background_image_description": "Imagine centrală pe pagina de subiecte a comunității",
   "community_background_image_label": "Imagine centrală comunitate",
-  "community_image_description": "Imagine pentru secțiunea comunitate de pe pagina de pornire",
-  "community_image_label": "Banner comunitate",
   "community_post_group_label": "Elemente postare în Comunitate",
   "community_topic_group_label": "Elemente subiect în Comunitate",
   "favicon_description": "Pictogramă afișată în bara de adresă a browserului",

--- a/translations/ru.json
+++ b/translations/ru.json
@@ -18,8 +18,6 @@
   "colors_group_label": "Цвета",
   "community_background_image_description": "Изображение героя на странице тем сообщества",
   "community_background_image_label": "Изображение героя — сообщество",
-  "community_image_description": "Изображение для раздела сообщества на главной странице",
-  "community_image_label": "Баннер сообщества",
   "community_post_group_label": "Элементы публикации в сообществе",
   "community_topic_group_label": "Элементы темы в сообществе",
   "favicon_description": "Значок, который отображается в адресной строке браузера",

--- a/translations/sk.json
+++ b/translations/sk.json
@@ -18,8 +18,6 @@
   "colors_group_label": "Farby",
   "community_background_image_description": "Hlavný obrázok stránky komunitných tém",
   "community_background_image_label": "Hlavný obrázok komunity",
-  "community_image_description": "Obrázok pre komunitnú sekciu na domovskej stránke",
-  "community_image_label": "Banner komunity",
   "community_post_group_label": "Prvky komunitného príspevku",
   "community_topic_group_label": "Prvky komunitnej témy",
   "favicon_description": "Ikona zobrazená v adresnom riadku vášho prehliadača",

--- a/translations/sv.json
+++ b/translations/sv.json
@@ -18,8 +18,6 @@
   "colors_group_label": "Färger",
   "community_background_image_description": "Fokusbild på sidan med communityämnen",
   "community_background_image_label": "Communityfokusbild",
-  "community_image_description": "Bild för hemsidans communityavsnitt",
-  "community_image_label": "Communitybild",
   "community_post_group_label": "Element i communityinlägg",
   "community_topic_group_label": "Element i communityämnen",
   "favicon_description": "Ikon som visas i webbläsarens adressfält",

--- a/translations/th.json
+++ b/translations/th.json
@@ -18,8 +18,6 @@
   "colors_group_label": "สี",
   "community_background_image_description": "รูปภาพฮีโร่ในหน้าหัวข้อของชุมชน",
   "community_background_image_label": "รูปภาพฮีโร่ของชุมชน",
-  "community_image_description": "รูปภาพสำหรับส่วนชุมชนในหน้าหลัก",
-  "community_image_label": "แบนเนอร์ชุมชน",
   "community_post_group_label": "องค์ประกอบหน้าโพสต์ของชุมชน",
   "community_topic_group_label": "องค์ประกอบหัวข้อของชุมชน",
   "favicon_description": "ไอคอนที่แสดงในแถบที่อยู่ของเบราว์เซอร์ของคุณ",

--- a/translations/tr.json
+++ b/translations/tr.json
@@ -18,8 +18,6 @@
   "colors_group_label": "Renkler",
   "community_background_image_description": "Topluluk konuları sayfasındaki büyük başlık görseli",
   "community_background_image_label": "Topluluk büyük başlık görseli",
-  "community_image_description": "Ana sayfadaki topluluk bölümü için görsel",
-  "community_image_label": "Topluluk başlık görseli",
   "community_post_group_label": "Topluluk gönderisi öğeleri",
   "community_topic_group_label": "Topluluk konu başlığı öğeleri",
   "favicon_description": "Tarayıcınızın adres çubuğunda görüntülenen simge",

--- a/translations/uk.json
+++ b/translations/uk.json
@@ -18,8 +18,6 @@
   "colors_group_label": "Кольори",
   "community_background_image_description": "Зображення героя на сторінці тем спільноти",
   "community_background_image_label": "Образ героя спільноти",
-  "community_image_description": "Зображення для розділу спільноти на головній сторінці",
-  "community_image_label": "Банер спільноти",
   "community_post_group_label": "Елементи публікації в спільноті",
   "community_topic_group_label": "Елементи теми спільноти",
   "favicon_description": "Значок відображається в адресному рядку вашого браузера",

--- a/translations/vi.json
+++ b/translations/vi.json
@@ -18,8 +18,6 @@
   "colors_group_label": "Màu sắc",
   "community_background_image_description": "Ảnh đại diện trên trang chủ đề của cộng đồng",
   "community_background_image_label": "Ảnh đại diện của cộng đồng",
-  "community_image_description": "Hình ảnh cho mục cộng đồng trên trang chủ",
-  "community_image_label": "Biểu ngữ cộng đồng",
   "community_post_group_label": "Các phần tử của bài đăng cộng đồng",
   "community_topic_group_label": "Các phần tử trong chủ đề cộng đồng",
   "favicon_description": "Biểu tượng hiển thị trên thanh địa chỉ của trình duyệt của bạn",

--- a/translations/zh-cn.json
+++ b/translations/zh-cn.json
@@ -18,8 +18,6 @@
   "colors_group_label": "颜色",
   "community_background_image_description": "社区主题页面的主页横幅",
   "community_background_image_label": "社区主页横幅",
-  "community_image_description": "主页上社区部分的图像",
-  "community_image_label": "社区横幅",
   "community_post_group_label": "社区帖子元素",
   "community_topic_group_label": "社区主题元素",
   "favicon_description": "您的浏览器地址栏中显示的图标",

--- a/translations/zh-tw.json
+++ b/translations/zh-tw.json
@@ -18,8 +18,6 @@
   "colors_group_label": "色彩",
   "community_background_image_description": "社區主題頁面的網頁首圖",
   "community_background_image_label": "社區網頁首圖",
-  "community_image_description": "主頁上的社區部分影像",
-  "community_image_label": "社區橫幅",
   "community_post_group_label": "社區貼文元素",
   "community_topic_group_label": "社區主題元素",
   "favicon_description": "您的瀏覽器網址列中顯示的圖示",


### PR DESCRIPTION
## Summary
- remove community callout from home page
- drop community image setting and related translations

## Testing
- `yarn build`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68b5abe43a248320b4ad06ea7b7527dd