### PR TITLE
Revamp homepage with branded hero and styles

### DIFF
--- a/src/carousel.js
+++ b/src/carousel.js
@@ -1,24 +1,26 @@
 export function initCarousel(selector, limit = Infinity) {
   const container = document.querySelector(selector);
   if (!container) return;
-  let slides = Array.from(container.querySelectorAll('.carousel-item'));
+  let slides = Array.from(container.querySelectorAll(".carousel-item"));
   if (limit !== Infinity) {
     slides.slice(limit).forEach((slide) => slide.remove());
     slides = slides.slice(0, limit);
   }
   let index = 0;
   if (slides.length) {
-    slides[0].classList.add('active');
+    slides[0].classList.add("active");
     setInterval(() => {
-      slides[index].classList.remove('active');
+      slides[index].classList.remove("active");
       index = (index + 1) % slides.length;
-      slides[index].classList.add('active');
+      slides[index].classList.add("active");
     }, 5000);
   }
 }
 
 async function loadAnnouncementImages() {
-  const slides = document.querySelectorAll('#announcements-carousel .carousel-item');
+  const slides = document.querySelectorAll(
+    "#announcements-carousel .carousel-item"
+  );
   for (const slide of slides) {
     const id = slide.dataset.articleId;
     if (!id) continue;
@@ -27,7 +29,7 @@ async function loadAnnouncementImages() {
       const data = await response.json();
       const match = data.article.body.match(/<img[^>]+src="([^"]+)"/i);
       if (match) {
-        const img = slide.querySelector('img');
+        const img = slide.querySelector("img");
         if (img) {
           img.src = match[1];
         }
@@ -39,12 +41,14 @@ async function loadAnnouncementImages() {
 }
 
 function init() {
-  initCarousel('#company-carousel');
-  const announcementCarousel = document.querySelector('#announcements-carousel');
+  initCarousel("#company-carousel");
+  const announcementCarousel = document.querySelector(
+    "#announcements-carousel"
+  );
   if (announcementCarousel) {
-    initCarousel('#announcements-carousel', 3);
+    initCarousel("#announcements-carousel", 3);
     loadAnnouncementImages();
   }
 }
 
-document.addEventListener('DOMContentLoaded', init);
+document.addEventListener("DOMContentLoaded", init);

--- a/styles/_home-page.scss
+++ b/styles/_home-page.scss
@@ -13,6 +13,34 @@
   text-align: center;
 }
 
+/***** Hero branding *****/
+
+.hero--brand {
+  background: linear-gradient(135deg, $brand_color, zass-lighten($brand_color, 15%));
+  color: $brand_text_color;
+  padding: 80px 20px;
+  text-align: center;
+
+  .hero-inner {
+    max-width: 640px;
+    margin: 0 auto;
+  }
+
+  .btn {
+    background: $brand_text_color;
+    border: 0;
+    border-radius: 4px;
+    color: $brand_color;
+    font-weight: $font-weight-semibold;
+    padding: 12px 32px;
+    transition: background .3s;
+
+    &:hover {
+      background: zass-lighten($brand_text_color, 10%);
+    }
+  }
+}
+
 /***** Intranet layout *****/
 
 .intranet-grid {
@@ -44,7 +72,9 @@
   .carousel-item {
     display: none;
     padding: 40px;
-    background-color: $secondary-shade;
+    background: linear-gradient(135deg, $brand_color, zass-lighten($brand_color, 10%));
+    border-radius: 8px;
+    color: $brand_text_color;
   }
 
   .carousel-item.active {
@@ -76,11 +106,16 @@
     a {
       display: block;
       padding: 20px;
-      background-color: $secondary-shade;
-      border-radius: 4px;
+      background: $brand_color;
+      border-radius: 8px;
       text-decoration: none;
       font-weight: bold;
-      color: inherit;
+      color: $brand_text_color;
+      transition: background .3s;
+
+      &:hover {
+        background: zass-darken($brand_color, 5%);
+      }
     }
   }
 }

--- a/templates/home_page.hbs
+++ b/templates/home_page.hbs
@@ -1,5 +1,13 @@
 <h1 class="visibility-hidden">{{ help_center.name }}</h1>
 
+<section class="hero hero--brand">
+  <div class="hero-inner">
+    <h2>{{ help_center.name }}</h2>
+    <p>Your secure hub for company resources and updates.</p>
+    <a href="#company-carousel" class="btn btn-primary">Explore</a>
+  </div>
+</section>
+
 <div id="main-content" class="container intranet-grid">
 <div class="container">
   <section id="company-carousel" class="carousel section">


### PR DESCRIPTION
## Summary
- introduce branded hero banner with CTA on the home page
- style carousel and quick links with brand gradient and hover effects
- clean up carousel script to satisfy linting

## Testing
- `yarn eslint`
- `yarn test`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68b5ae2a9c24832086f19e878836ef27