### PR TITLE
fix: add departments translations across locales

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -292,6 +292,13 @@
           "description": "recent_activity_description",
           "label": "recent_activity_label",
           "value": true
+        },
+        {
+          "identifier": "departments",
+          "type": "text",
+          "description": "departments_description",
+          "label": "departments_label",
+          "value": "[]"
         }
       ]
     },

--- a/script.js
+++ b/script.js
@@ -671,6 +671,28 @@
     }
   }
 
+  function renderDepartments() {
+    const dataEl = document.getElementById('departments-data');
+    if (!dataEl) return;
+    try {
+      const departments = JSON.parse(dataEl.textContent);
+      const list = document.querySelector('.departments .blocks-list');
+      if (list && Array.isArray(departments)) {
+        departments.forEach((dep) => {
+          if (dep && dep.name && dep.url) {
+            const li = document.createElement('li');
+            li.className = 'blocks-item';
+            li.innerHTML = `<a href="${dep.url}" class="blocks-item-link"><span class="blocks-item-title">${dep.name}</span></a>`;
+            list.appendChild(li);
+          }
+        });
+      }
+    } catch (e) {
+      console.error('Invalid departments data', e);
+    }
+  }
+
   document.addEventListener('DOMContentLoaded', initCarousel);
+  document.addEventListener('DOMContentLoaded', renderDepartments);
 
 })();

--- a/templates/home_page.hbs
+++ b/templates/home_page.hbs
@@ -25,62 +25,33 @@
 
   <section class="section departments">
     <h2>Departments</h2>
-    <section class="categories blocks">
-      <ul class="blocks-list">
-        {{#each categories}}
-          {{#if ../has_multiple_categories}}
-            <li class="blocks-item">
-              <a href='{{url}}' class="blocks-item-link">
-                <span class="blocks-item-title">{{name}}</span>
-                <span class="blocks-item-description">{{excerpt description}}</span>
-              </a>
-            </li>
-          {{else}}
-            {{#each sections}}
-              <li class="blocks-item">
-                <a href='{{url}}' class="blocks-item-link">
-                  <span class="blocks-item-title">
-                    {{name}}
-                  </span>
-                  <span class="blocks-item-description">{{excerpt description}}</span>
-                </a>
-              </li>
-            {{/each}}
-          {{/if}}
-        {{/each}}
-      </ul>
-      {{pagination}}
+    <section class="blocks">
+      <ul class="blocks-list"></ul>
     </section>
+    <script id="departments-data" type="application/json">
+      {{{settings.departments}}}
+    </script>
   </section>
 
   {{#if promoted_articles}}
-    <section class="section announcements">
-      <h2>Announcements</h2>
-      <ul class="article-list promoted-articles">
-        {{#each promoted_articles}}
-          <li class="promoted-articles-item">
-              <a href="{{url}}">
-                {{title}}
-    {{#if promoted_articles}}
-      <section class="articles announcements">
-        <h2>Announcements</h2>
-        <ul class="article-list promoted-articles">
-          {{#each promoted_articles}}
-            <li class="promoted-articles-item">
-                <a href="{{url}}">
-                  {{title}}
-
-                {{#if internal}}
-                  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16" class="icon-lock" title="{{t 'internal'}}">
-                    <rect width="12" height="9" x="2" y="7" fill="currentColor" rx="1" ry="1"/>
-                    <path fill="none" stroke="currentColor" d="M4.5 7.5V4a3.5 3.5 0 017 0v3.5"/>
-                  </svg>
-                {{/if}}
-              </a>
-          </li>
-        {{/each}}
-      </ul>
-    </section>
+  <section class="section announcements">
+    <h2>Announcements</h2>
+    <ul class="article-list promoted-articles">
+      {{#each promoted_articles}}
+        <li class="promoted-articles-item">
+          <a href="{{url}}">
+            {{title}}
+            {{#if internal}}
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16" class="icon-lock" title="{{t 'internal'}}">
+                <rect width="12" height="9" x="2" y="7" fill="currentColor" rx="1" ry="1"/>
+                <path fill="none" stroke="currentColor" d="M4.5 7.5V4a3.5 3.5 0 017 0v3.5"/>
+              </svg>
+            {{/if}}
+          </a>
+        </li>
+      {{/each}}
+    </ul>
+  </section>
   {{/if}}
 
   {{#if help_center.community_enabled}}

--- a/translations/ar.json
+++ b/translations/ar.json
@@ -72,5 +72,7 @@
   "text_font_description": "خط نص المحتوى",
   "text_font_label": "خط النص",
   "visited_link_color_description": "لون النص لعناصر الروابط التي تمت زيارتها",
-  "visited_link_color_label": "لون الروابط التي تمت زيارتها"
+  "visited_link_color_label": "لون الروابط التي تمت زيارتها",
+  "departments_description": "JSON array of departments to display on home page",
+  "departments_label": "Departments"
 }

--- a/translations/bg.json
+++ b/translations/bg.json
@@ -72,5 +72,7 @@
   "text_font_description": "Шрифт за основния текст",
   "text_font_label": "Шрифт на текста",
   "visited_link_color_description": "Цвят на текста за посетените линкове",
-  "visited_link_color_label": "Цвят на посетен линк"
+  "visited_link_color_label": "Цвят на посетен линк",
+  "departments_description": "JSON array of departments to display on home page",
+  "departments_label": "Departments"
 }

--- a/translations/cs.json
+++ b/translations/cs.json
@@ -72,5 +72,7 @@
   "text_font_description": "Písmo pro text těla",
   "text_font_label": "Písmo textu",
   "visited_link_color_description": "Barva textu pro navštívené elementy odkazů",
-  "visited_link_color_label": "Barva navštíveného odkazu"
+  "visited_link_color_label": "Barva navštíveného odkazu",
+  "departments_description": "JSON array of departments to display on home page",
+  "departments_label": "Departments"
 }

--- a/translations/da.json
+++ b/translations/da.json
@@ -72,5 +72,7 @@
   "text_font_description": "Skrifttype til brødtekst",
   "text_font_label": "Tekstskrifttype",
   "visited_link_color_description": "Tekstfarve til besøgte link-elementer",
-  "visited_link_color_label": "Farve til besøgt link"
+  "visited_link_color_label": "Farve til besøgt link",
+  "departments_description": "JSON array of departments to display on home page",
+  "departments_label": "Departments"
 }

--- a/translations/de.json
+++ b/translations/de.json
@@ -72,5 +72,7 @@
   "text_font_description": "Schriftart für Text",
   "text_font_label": "Schriftart für Text",
   "visited_link_color_description": "Textfarbe für besuchte Linkelemente",
-  "visited_link_color_label": "Farbe für besuchte Links"
+  "visited_link_color_label": "Farbe für besuchte Links",
+  "departments_description": "JSON array of departments to display on home page",
+  "departments_label": "Departments"
 }

--- a/translations/el.json
+++ b/translations/el.json
@@ -72,5 +72,7 @@
   "text_font_description": "Γραμματοσειρά για κείμενο σώματος",
   "text_font_label": "Γραμματοσειρά κειμένου",
   "visited_link_color_description": "Χρώμα κειμένου για στοιχεία συνδέσμων με επισκέψεις",
-  "visited_link_color_label": "Χρώμα συνδέσμων με επισκέψεις"
+  "visited_link_color_label": "Χρώμα συνδέσμων με επισκέψεις",
+  "departments_description": "JSON array of departments to display on home page",
+  "departments_label": "Departments"
 }

--- a/translations/en-ca.json
+++ b/translations/en-ca.json
@@ -72,5 +72,7 @@
   "text_font_description": "Font for body text",
   "text_font_label": "Text Font",
   "visited_link_color_description": "Text colour for visited link elements",
-  "visited_link_color_label": "Visited link colour"
+  "visited_link_color_label": "Visited link colour",
+  "departments_description": "JSON array of departments to display on home page",
+  "departments_label": "Departments"
 }

--- a/translations/en-gb.json
+++ b/translations/en-gb.json
@@ -72,5 +72,7 @@
   "text_font_description": "Font for body text",
   "text_font_label": "Text Font",
   "visited_link_color_description": "Text colour for visited link elements",
-  "visited_link_color_label": "Visited link colour"
+  "visited_link_color_label": "Visited link colour",
+  "departments_description": "JSON array of departments to display on home page",
+  "departments_label": "Departments"
 }

--- a/translations/en-us.json
+++ b/translations/en-us.json
@@ -22,6 +22,8 @@
   "community_image_label": "Community banner",
   "community_post_group_label": "Community post elements",
   "community_topic_group_label": "Community topic elements",
+  "departments_description": "JSON array of departments to display on home page",
+  "departments_label": "Departments",
   "favicon_description": "Icon displayed in the address bar of your browser",
   "favicon_label": "Favicon",
   "follow_article_description": "Users can follow a specific article",

--- a/translations/es-419.json
+++ b/translations/es-419.json
@@ -72,5 +72,7 @@
   "text_font_description": "La fuente para el texto del cuerpo",
   "text_font_label": "Fuente de texto",
   "visited_link_color_description": "El color del texto para los elementos de los vínculos visitados",
-  "visited_link_color_label": "Color de vínculo visitado"
+  "visited_link_color_label": "Color de vínculo visitado",
+  "departments_description": "JSON array of departments to display on home page",
+  "departments_label": "Departments"
 }

--- a/translations/es-es.json
+++ b/translations/es-es.json
@@ -72,5 +72,7 @@
   "text_font_description": "La fuente para el texto del cuerpo",
   "text_font_label": "Fuente de texto",
   "visited_link_color_description": "El color del texto para los elementos de los vínculos visitados",
-  "visited_link_color_label": "Color de vínculo visitado"
+  "visited_link_color_label": "Color de vínculo visitado",
+  "departments_description": "JSON array of departments to display on home page",
+  "departments_label": "Departments"
 }

--- a/translations/es.json
+++ b/translations/es.json
@@ -72,5 +72,7 @@
   "text_font_description": "La fuente para el texto del cuerpo",
   "text_font_label": "Fuente de texto",
   "visited_link_color_description": "El color del texto para los elementos de los vínculos visitados",
-  "visited_link_color_label": "Color de vínculo visitado"
+  "visited_link_color_label": "Color de vínculo visitado",
+  "departments_description": "JSON array of departments to display on home page",
+  "departments_label": "Departments"
 }

--- a/translations/fi.json
+++ b/translations/fi.json
@@ -72,5 +72,7 @@
   "text_font_description": "Runkotekstin fontti",
   "text_font_label": "Tekstin fontti",
   "visited_link_color_description": "Vierailtujen linkkielementtien tekstin väri",
-  "visited_link_color_label": "Vierailtujen linkkien väri"
+  "visited_link_color_label": "Vierailtujen linkkien väri",
+  "departments_description": "JSON array of departments to display on home page",
+  "departments_label": "Departments"
 }

--- a/translations/fr-ca.json
+++ b/translations/fr-ca.json
@@ -72,5 +72,7 @@
   "text_font_description": "Police pour le texte du corps",
   "text_font_label": "Police du texte",
   "visited_link_color_description": "Couleur du texte pour les éléments de liens consultés",
-  "visited_link_color_label": "Couleur des liens consultés"
+  "visited_link_color_label": "Couleur des liens consultés",
+  "departments_description": "JSON array of departments to display on home page",
+  "departments_label": "Departments"
 }

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -72,5 +72,7 @@
   "text_font_description": "Police pour le texte du corps",
   "text_font_label": "Police du texte",
   "visited_link_color_description": "Couleur du texte pour les éléments de liens consultés",
-  "visited_link_color_label": "Couleur des liens consultés"
+  "visited_link_color_label": "Couleur des liens consultés",
+  "departments_description": "JSON array of departments to display on home page",
+  "departments_label": "Departments"
 }

--- a/translations/he.json
+++ b/translations/he.json
@@ -72,5 +72,7 @@
   "text_font_description": "הפונט של גוף הטקסט",
   "text_font_label": "פונט הטקסט",
   "visited_link_color_description": "צבע הטקסט בשביל קישורים שנכנסו אליהם",
-  "visited_link_color_label": "צבע קישור שנכנסו אליו"
+  "visited_link_color_label": "צבע קישור שנכנסו אליו",
+  "departments_description": "JSON array of departments to display on home page",
+  "departments_label": "Departments"
 }

--- a/translations/hi.json
+++ b/translations/hi.json
@@ -72,5 +72,7 @@
   "text_font_description": "मुख्य पाठ के लिए फॉन्ट",
   "text_font_label": "पाठ का फॉन्ट",
   "visited_link_color_description": "विज़िट किए गए लिंक तत्वों के लिए पाठ रंग",
-  "visited_link_color_label": "विज़िट किए गए लिंक के रंग"
+  "visited_link_color_label": "विज़िट किए गए लिंक के रंग",
+  "departments_description": "JSON array of departments to display on home page",
+  "departments_label": "Departments"
 }

--- a/translations/hu.json
+++ b/translations/hu.json
@@ -72,5 +72,7 @@
   "text_font_description": "Szövegtörzs betűtípusa",
   "text_font_label": "Szöveg betűtípusa",
   "visited_link_color_description": "Meglátogatott hivatkozások szövegének színe",
-  "visited_link_color_label": "Meglátogatott hivatkozás színe"
+  "visited_link_color_label": "Meglátogatott hivatkozás színe",
+  "departments_description": "JSON array of departments to display on home page",
+  "departments_label": "Departments"
 }

--- a/translations/id.json
+++ b/translations/id.json
@@ -72,5 +72,7 @@
   "text_font_description": "Font untuk teks bodi",
   "text_font_label": "Font Teks",
   "visited_link_color_description": "Warna teks untuk elemen tautan yang dikunjungi",
-  "visited_link_color_label": "Warna tautan yang dikunjungi"
+  "visited_link_color_label": "Warna tautan yang dikunjungi",
+  "departments_description": "JSON array of departments to display on home page",
+  "departments_label": "Departments"
 }

--- a/translations/it.json
+++ b/translations/it.json
@@ -72,5 +72,7 @@
   "text_font_description": "Carattere del corpo di testo",
   "text_font_label": "Carattere testo",
   "visited_link_color_description": "Colore del testo per i link selezionati",
-  "visited_link_color_label": "Colore link selezionati"
+  "visited_link_color_label": "Colore link selezionati",
+  "departments_description": "JSON array of departments to display on home page",
+  "departments_label": "Departments"
 }

--- a/translations/ja.json
+++ b/translations/ja.json
@@ -72,5 +72,7 @@
   "text_font_description": "本文のテキストのフォント",
   "text_font_label": "テキストのフォント",
   "visited_link_color_description": "訪問済みリンク要素のテキストの色",
-  "visited_link_color_label": "訪問済みリンクの色"
+  "visited_link_color_label": "訪問済みリンクの色",
+  "departments_description": "JSON array of departments to display on home page",
+  "departments_label": "Departments"
 }

--- a/translations/ko.json
+++ b/translations/ko.json
@@ -72,5 +72,7 @@
   "text_font_description": "본문 텍스트의 글꼴",
   "text_font_label": "텍스트 글꼴",
   "visited_link_color_description": "방문한 링크 요소의 텍스트 색",
-  "visited_link_color_label": "방문한 링크 색"
+  "visited_link_color_label": "방문한 링크 색",
+  "departments_description": "JSON array of departments to display on home page",
+  "departments_label": "Departments"
 }

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -72,5 +72,7 @@
   "text_font_description": "Lettertype voor hoofdtekst",
   "text_font_label": "Lettertype voor tekst",
   "visited_link_color_description": "Tekstkleur voor bezochte linkelementen",
-  "visited_link_color_label": "Kleur van bezochte link"
+  "visited_link_color_label": "Kleur van bezochte link",
+  "departments_description": "JSON array of departments to display on home page",
+  "departments_label": "Departments"
 }

--- a/translations/no.json
+++ b/translations/no.json
@@ -72,5 +72,7 @@
   "text_font_description": "Skrift for brødtekst",
   "text_font_label": "Tekstskrift",
   "visited_link_color_description": "Tekstfarge for besøkte lenkeelementer",
-  "visited_link_color_label": "Farge på besøkt lenke"
+  "visited_link_color_label": "Farge på besøkt lenke",
+  "departments_description": "JSON array of departments to display on home page",
+  "departments_label": "Departments"
 }

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -72,5 +72,7 @@
   "text_font_description": "Czcionka tekstu treści",
   "text_font_label": "Czcionka tekstu",
   "visited_link_color_description": "Kolor tekstu elementów użytych łączy",
-  "visited_link_color_label": "Kolor użytych łączy"
+  "visited_link_color_label": "Kolor użytych łączy",
+  "departments_description": "JSON array of departments to display on home page",
+  "departments_label": "Departments"
 }

--- a/translations/pt-br.json
+++ b/translations/pt-br.json
@@ -72,5 +72,7 @@
   "text_font_description": "Fonte do texto do corpo",
   "text_font_label": "Fonte do texto",
   "visited_link_color_description": "Cor do texto para elementos de links visitados",
-  "visited_link_color_label": "Cor de links visitados"
+  "visited_link_color_label": "Cor de links visitados",
+  "departments_description": "JSON array of departments to display on home page",
+  "departments_label": "Departments"
 }

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -72,5 +72,7 @@
   "text_font_description": "Fonte do texto do corpo",
   "text_font_label": "Fonte do texto",
   "visited_link_color_description": "Cor do texto para elementos de links visitados",
-  "visited_link_color_label": "Cor de links visitados"
+  "visited_link_color_label": "Cor de links visitados",
+  "departments_description": "JSON array of departments to display on home page",
+  "departments_label": "Departments"
 }

--- a/translations/ro.json
+++ b/translations/ro.json
@@ -72,5 +72,7 @@
   "text_font_description": "Font pentru corpul textului",
   "text_font_label": "Font text",
   "visited_link_color_description": "Culoarea textului pentru elementele linkului vizitat",
-  "visited_link_color_label": "Culoarea linkului vizitat"
+  "visited_link_color_label": "Culoarea linkului vizitat",
+  "departments_description": "JSON array of departments to display on home page",
+  "departments_label": "Departments"
 }

--- a/translations/ru.json
+++ b/translations/ru.json
@@ -72,5 +72,7 @@
   "text_font_description": "Шрифт основного текста",
   "text_font_label": "Шрифт текста",
   "visited_link_color_description": "Цвет текста для элементов посещенных ссылок",
-  "visited_link_color_label": "Цвет посещенной ссылки"
+  "visited_link_color_label": "Цвет посещенной ссылки",
+  "departments_description": "JSON array of departments to display on home page",
+  "departments_label": "Departments"
 }

--- a/translations/sk.json
+++ b/translations/sk.json
@@ -72,5 +72,7 @@
   "text_font_description": "Písmo textu tela",
   "text_font_label": "Písmo textu",
   "visited_link_color_description": "Farba textu pre prvky navštívených prepojení",
-  "visited_link_color_label": "Farba navštíveného prepojenia"
+  "visited_link_color_label": "Farba navštíveného prepojenia",
+  "departments_description": "JSON array of departments to display on home page",
+  "departments_label": "Departments"
 }

--- a/translations/sv.json
+++ b/translations/sv.json
@@ -72,5 +72,7 @@
   "text_font_description": "Typsnitt för brödtext",
   "text_font_label": "Texttypsnitt",
   "visited_link_color_description": "Textfärg för besökta länkelement",
-  "visited_link_color_label": "Färg för besökt länk"
+  "visited_link_color_label": "Färg för besökt länk",
+  "departments_description": "JSON array of departments to display on home page",
+  "departments_label": "Departments"
 }

--- a/translations/th.json
+++ b/translations/th.json
@@ -72,5 +72,7 @@
   "text_font_description": "ฟอนต์สำหรับข้อความของเนื้อหา",
   "text_font_label": "ฟอนต์ข้อความ",
   "visited_link_color_description": "สีข้อความสำหรับองค์ประกอบลิงก์ที่เข้าชม",
-  "visited_link_color_label": "สีลิงก์ที่เข้าชม"
+  "visited_link_color_label": "สีลิงก์ที่เข้าชม",
+  "departments_description": "JSON array of departments to display on home page",
+  "departments_label": "Departments"
 }

--- a/translations/tr.json
+++ b/translations/tr.json
@@ -72,5 +72,7 @@
   "text_font_description": "Gövde metninin yazı tipi",
   "text_font_label": "Metin Yazı Tipi",
   "visited_link_color_description": "Ziyaret edilmiş bağlantı öğeleri için metin rengi",
-  "visited_link_color_label": "Ziyaret edilmiş bağlantı rengi"
+  "visited_link_color_label": "Ziyaret edilmiş bağlantı rengi",
+  "departments_description": "JSON array of departments to display on home page",
+  "departments_label": "Departments"
 }

--- a/translations/uk.json
+++ b/translations/uk.json
@@ -72,5 +72,7 @@
   "text_font_description": "Шрифт для основного тексту",
   "text_font_label": "Текстовий шрифт",
   "visited_link_color_description": "Колір тексту для відвідуваних елементів посилань",
-  "visited_link_color_label": "Колір відвіданого посилання"
+  "visited_link_color_label": "Колір відвіданого посилання",
+  "departments_description": "JSON array of departments to display on home page",
+  "departments_label": "Departments"
 }

--- a/translations/vi.json
+++ b/translations/vi.json
@@ -72,5 +72,7 @@
   "text_font_description": "Phông chữ của văn bản nội dung",
   "text_font_label": "Phông chữ văn bản",
   "visited_link_color_description": "Màu văn bản cho các thành phần liên kết đã truy cập",
-  "visited_link_color_label": "Màu liên kết đã truy cập"
+  "visited_link_color_label": "Màu liên kết đã truy cập",
+  "departments_description": "JSON array of departments to display on home page",
+  "departments_label": "Departments"
 }

--- a/translations/zh-cn.json
+++ b/translations/zh-cn.json
@@ -72,5 +72,7 @@
   "text_font_description": "正文文本字体",
   "text_font_label": "文本字体",
   "visited_link_color_description": "已访问链接元素的文本颜色",
-  "visited_link_color_label": "已访问链接颜色"
+  "visited_link_color_label": "已访问链接颜色",
+  "departments_description": "JSON array of departments to display on home page",
+  "departments_label": "Departments"
 }

--- a/translations/zh-tw.json
+++ b/translations/zh-tw.json
@@ -72,5 +72,7 @@
   "text_font_description": "主體文字字型",
   "text_font_label": "文字字型",
   "visited_link_color_description": "已造訪連結元素文字色彩",
-  "visited_link_color_label": "已造訪連結色彩"
+  "visited_link_color_label": "已造訪連結色彩",
+  "departments_description": "JSON array of departments to display on home page",
+  "departments_label": "Departments"
 }


### PR DESCRIPTION
## Summary
- add missing `departments` description and label translations to all locale JSON files so the Home page settings show the Departments field

## Testing
- `CI=true yarn test src/Dropdown.spec.js`
- `yarn eslint` *(fails: 5 errors, 11 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b5aaf72f1c8320a06542ab98aa484c