### PR TITLE
feat: add department rail to home page

### DIFF
--- a/script.js
+++ b/script.js
@@ -732,4 +732,27 @@
 
   document.addEventListener("DOMContentLoaded", init);
 
+  async function loadDepartments() {
+    const list = document.querySelector('#department-list');
+    if (!list) return;
+    const locale = document.documentElement.lang;
+    try {
+      const resp = await fetch(`/api/v2/help_center/${locale}/categories/4961264026655/sections.json`);
+      const data = await resp.json();
+      data.sections.forEach((section) => {
+        const li = document.createElement('li');
+        li.className = 'department-rail-item';
+        const a = document.createElement('a');
+        a.href = section.html_url;
+        a.textContent = section.name;
+        li.appendChild(a);
+        list.appendChild(li);
+      });
+    } catch (e) {
+      // ignore errors
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', loadDepartments);
+
 })();

--- a/src/departments.js
+++ b/src/departments.js
@@ -1,0 +1,22 @@
+async function loadDepartments() {
+  const list = document.querySelector('#department-list');
+  if (!list) return;
+  const locale = document.documentElement.lang;
+  try {
+    const resp = await fetch(`/api/v2/help_center/${locale}/categories/4961264026655/sections.json`);
+    const data = await resp.json();
+    data.sections.forEach((section) => {
+      const li = document.createElement('li');
+      li.className = 'department-rail-item';
+      const a = document.createElement('a');
+      a.href = section.html_url;
+      a.textContent = section.name;
+      li.appendChild(a);
+      list.appendChild(li);
+    });
+  } catch (e) {
+    // ignore errors
+  }
+}
+
+document.addEventListener('DOMContentLoaded', loadDepartments);

--- a/src/index.js
+++ b/src/index.js
@@ -6,3 +6,4 @@ import "./share";
 import "./search";
 import "./forms";
 import "./carousel";
+import "./departments";

--- a/style.css
+++ b/style.css
@@ -1346,7 +1346,7 @@ ul {
 @media (min-width: 1024px) {
   .intranet-grid {
     grid-template-columns: 2fr 1fr;
-    grid-template-areas: "carousel carousel" "introduction quick-links" "departments departments" "activity activity";
+    grid-template-areas: "carousel carousel" "introduction quick-links" "activity activity";
   }
 }
 
@@ -1386,23 +1386,19 @@ ul {
   margin-bottom: 10px;
 }
 
-.quick-links {
+.department-rail {
   grid-area: quick-links;
 }
-.quick-links-list {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
+.department-rail-list {
   list-style: none;
   padding: 0;
 }
-.quick-links-item {
-  flex: 1 1 120px;
-  margin: 10px;
+.department-rail-item {
+  margin-bottom: 10px;
 }
-.quick-links-item a {
+.department-rail-item a {
   display: block;
-  padding: 20px;
+  padding: 12px 20px;
   background: $brand_color;
   border-radius: 8px;
   text-decoration: none;
@@ -1410,12 +1406,8 @@ ul {
   color: $brand_text_color;
   transition: background 0.3s;
 }
-.quick-links-item a:hover {
+.department-rail-item a:hover {
   background: darken($brand_color, 5%);
-}
-
-.departments {
-  grid-area: departments;
 }
 
 .announcements {

--- a/styles/_home-page.scss
+++ b/styles/_home-page.scss
@@ -48,15 +48,14 @@
   gap: 40px;
   grid-template-columns: 1fr;
 
-  @include desktop {
-    grid-template-columns: 2fr 1fr;
-    grid-template-areas:
-      "carousel carousel"
-      "introduction quick-links"
-      "departments departments"
-      "activity activity";
+    @include desktop {
+      grid-template-columns: 2fr 1fr;
+      grid-template-areas:
+        "carousel carousel"
+        "introduction quick-links"
+        "activity activity";
+    }
   }
-}
 
 /***** Carousel and introduction *****/
 
@@ -101,24 +100,20 @@
   }
 }
 
-.quick-links {
+.department-rail {
   grid-area: quick-links;
 
   &-list {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
     list-style: none;
     padding: 0;
   }
 
   &-item {
-    flex: 1 1 120px;
-    margin: 10px;
+    margin-bottom: 10px;
 
     a {
       display: block;
-      padding: 20px;
+      padding: 12px 20px;
       background: $brand_color;
       border-radius: 8px;
       text-decoration: none;
@@ -132,8 +127,6 @@
     }
   }
 }
-
-.departments { grid-area: departments; }
 
 .announcements { grid-area: carousel; }
 

--- a/templates/home_page.hbs
+++ b/templates/home_page.hbs
@@ -21,15 +21,10 @@
     <div id="introductions-grid" class="introductions-grid"></div>
   </section>
 
-  <section class="section departments">
+  <aside class="section department-rail">
     <h2>Departments</h2>
-    <section class="blocks">
-      <ul class="blocks-list"></ul>
-    </section>
-    <script id="departments-data" type="application/json">
-      {{settings.departments}}
-    </script>
-  </section>
+    <ul id="department-list" class="department-rail-list"></ul>
+  </aside>
 
   {{#if help_center.community_enabled}}
     <section class="section home-section community">


### PR DESCRIPTION
## Summary
- add right-rail Department list on home page
- style department rail and update grid layout
- load department sections dynamically via Help Center API

## Testing
- `yarn build`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68b6ac4a9740832085be4b55e37bf94b