### PR TITLE
feat: fetch announcements and introductions from labels

### DIFF
--- a/script.js
+++ b/script.js
@@ -677,131 +677,56 @@
     }
   }
 
-  function renderCarousel() {
-    const dataEl = document.getElementById('carousel-data');
-    if (!dataEl) return;
-    const raw = dataEl.textContent.trim();
-    if (!raw) return;
+  async function loadAnnouncements() {
+    const container = document.querySelector("#company-carousel");
+    if (!container) return;
     try {
-      const slides = JSON.parse(raw);
-    try {
-      const slides = JSON.parse(dataEl.textContent);
-      const container = document.getElementById('company-carousel');
-      if (container && Array.isArray(slides)) {
-        slides.forEach((slide) => {
-          if (slide) {
-            const div = document.createElement('div');
-            div.className = 'carousel-item';
-            div.textContent = typeof slide === 'string' ? slide : slide.text;
-            container.appendChild(div);
-          }
-        });
-        initCarousel();
-      }
+      const resp = await fetch(
+        "/api/v2/help_center/articles.json?label_names=Announcements&per_page=3&sort_by=created_at&sort_order=desc"
+      );
+      const data = await resp.json();
+      data.articles.forEach((article) => {
+        const div = document.createElement("div");
+        div.className = "carousel-item";
+        const match = article.body.match(/<img[^>]+src=\"([^\"]+)\"/i);
+        const img = match ? `<img src="${match[1]}" alt="${article.title}" />` : "";
+        div.innerHTML = `${img}<span>${article.title}</span>`;
+        container.appendChild(div);
+      });
+      initCarousel("#company-carousel", 3);
     } catch (e) {
-      console.error('Invalid carousel data', e);
-    }
-  }
-
-  function renderDepartments() {
-    const dataEl = document.getElementById('departments-data');
-    if (!dataEl) return;
-    const raw = dataEl.textContent.trim();
-    if (!raw) return;
-    try {
-      const departments = JSON.parse(raw);
-
-  function renderDepartments() {
-    const dataEl = document.getElementById('departments-data');
-    if (!dataEl) return;
-    try {
-      const departments = JSON.parse(dataEl.textContent);
-      const list = document.querySelector('.departments .blocks-list');
-      if (list && Array.isArray(departments)) {
-        departments.forEach((dep) => {
-          if (dep && dep.name && dep.url) {
-            const li = document.createElement('li');
-            li.className = 'blocks-item';
-            li.innerHTML = `<a href="${dep.url}" class="blocks-item-link"><span class="blocks-item-title">${dep.name}</span></a>`;
-            list.appendChild(li);
-          }
-        });
-      }
-    } catch (e) {
-      console.error('Invalid departments data', e);
-    }
-  }
-
-  document.addEventListener('DOMContentLoaded', renderCarousel);
-  document.addEventListener('DOMContentLoaded', renderDepartments);
-  document.addEventListener('DOMContentLoaded', initCarousel);
-  async function loadAnnouncementImages() {
-    const slides = document.querySelectorAll(
-      "#announcements-carousel .carousel-item"
-    );
-    for (const slide of slides) {
-      const id = slide.dataset.articleId;
-      if (!id) continue;
-      try {
-        const response = await fetch(`/api/v2/help_center/articles/${id}.json`);
-        const data = await response.json();
-        const match = data.article.body.match(/<img[^>]+src="([^"]+)"/i);
-        if (match) {
-          const img = slide.querySelector("img");
-          if (img) {
-            img.src = match[1];
-          }
-        }
-      } catch (e) {
-        // ignore errors
-      }
+      // ignore errors
     }
   }
 
   async function loadIntroductions() {
-    const container = document.querySelector("#introductions-carousel");
+    const container = document.querySelector("#introductions-grid");
     if (!container) return;
     try {
-      const secResp = await fetch("/api/v2/help_center/sections.json?per_page=100");
-      const secData = await secResp.json();
-      const introSection = secData.sections.find(
-        (s) => s.name && s.name.toLowerCase() === "introductions"
+      const resp = await fetch(
+        "/api/v2/help_center/articles.json?label_names=introductions&per_page=4&sort_by=created_at&sort_order=desc"
       );
-      if (!introSection) return;
-      const artResp = await fetch(
-        `/api/v2/help_center/sections/${introSection.id}/articles.json?per_page=3&sort_by=created_at&sort_order=desc`
-      );
-      const artData = await artResp.json();
-      artData.articles.forEach((article) => {
+      const data = await resp.json();
+      data.articles.forEach((article) => {
         const div = document.createElement("div");
-        div.className = "carousel-item";
-        const match = article.body.match(/<img[^>]+src="([^"]+)"/i);
-        const img = match
-          ? `<img src="${match[1]}" alt="${article.title}" />`
-          : "";
+        div.className = "intro-item";
+        const match = article.body.match(/<img[^>]+src=\"([^\"]+)\"/i);
+        const img = match ? `<img src="${match[1]}" alt="${article.title}" />` : "";
         const text = article.body
           .replace(/<[^>]+>/g, "")
           .split(/\s+/)
           .slice(0, 20)
           .join(" ");
-        div.innerHTML = `${img}<h3>${article.title}</h3><p>${text} <a href="${article.html_url}">read more...</a></p>`;
+        div.innerHTML = `<a href="${article.html_url}">${img}<h3>${article.title}</h3><p>${text}...</p></a>`;
         container.appendChild(div);
       });
-      initCarousel("#introductions-carousel", 3);
     } catch (e) {
       // ignore errors
     }
   }
 
   function init() {
-    initCarousel("#company-carousel");
-    const announcementCarousel = document.querySelector(
-      "#announcements-carousel"
-    );
-    if (announcementCarousel) {
-      initCarousel("#announcements-carousel", 3);
-      loadAnnouncementImages();
-    }
+    loadAnnouncements();
     loadIntroductions();
   }
 

--- a/src/carousel.js
+++ b/src/carousel.js
@@ -17,73 +17,56 @@ export function initCarousel(selector, limit = Infinity) {
   }
 }
 
-async function loadAnnouncementImages() {
-  const slides = document.querySelectorAll(
-    "#announcements-carousel .carousel-item"
-  );
-  for (const slide of slides) {
-    const id = slide.dataset.articleId;
-    if (!id) continue;
-    try {
-      const response = await fetch(`/api/v2/help_center/articles/${id}.json`);
-      const data = await response.json();
-      const match = data.article.body.match(/<img[^>]+src="([^"]+)"/i);
-      if (match) {
-        const img = slide.querySelector("img");
-        if (img) {
-          img.src = match[1];
-        }
-      }
-    } catch (e) {
-      // ignore errors
-    }
+async function loadAnnouncements() {
+  const container = document.querySelector("#company-carousel");
+  if (!container) return;
+  try {
+    const resp = await fetch(
+      "/api/v2/help_center/articles.json?label_names=Announcements&per_page=3&sort_by=created_at&sort_order=desc"
+    );
+    const data = await resp.json();
+    data.articles.forEach((article) => {
+      const div = document.createElement("div");
+      div.className = "carousel-item";
+      const match = article.body.match(/<img[^>]+src=\"([^\"]+)\"/i);
+      const img = match ? `<img src="${match[1]}" alt="${article.title}" />` : "";
+      div.innerHTML = `${img}<span>${article.title}</span>`;
+      container.appendChild(div);
+    });
+    initCarousel("#company-carousel", 3);
+  } catch (e) {
+    // ignore errors
   }
 }
 
 async function loadIntroductions() {
-  const container = document.querySelector("#introductions-carousel");
+  const container = document.querySelector("#introductions-grid");
   if (!container) return;
   try {
-    const secResp = await fetch("/api/v2/help_center/sections.json?per_page=100");
-    const secData = await secResp.json();
-    const introSection = secData.sections.find(
-      (s) => s.name && s.name.toLowerCase() === "introductions"
+    const resp = await fetch(
+      "/api/v2/help_center/articles.json?label_names=introductions&per_page=4&sort_by=created_at&sort_order=desc"
     );
-    if (!introSection) return;
-    const artResp = await fetch(
-      `/api/v2/help_center/sections/${introSection.id}/articles.json?per_page=3&sort_by=created_at&sort_order=desc`
-    );
-    const artData = await artResp.json();
-    artData.articles.forEach((article) => {
+    const data = await resp.json();
+    data.articles.forEach((article) => {
       const div = document.createElement("div");
-      div.className = "carousel-item";
-      const match = article.body.match(/<img[^>]+src="([^"]+)"/i);
-      const img = match
-        ? `<img src="${match[1]}" alt="${article.title}" />`
-        : "";
+      div.className = "intro-item";
+      const match = article.body.match(/<img[^>]+src=\"([^\"]+)\"/i);
+      const img = match ? `<img src="${match[1]}" alt="${article.title}" />` : "";
       const text = article.body
         .replace(/<[^>]+>/g, "")
         .split(/\s+/)
         .slice(0, 20)
         .join(" ");
-      div.innerHTML = `${img}<h3>${article.title}</h3><p>${text} <a href="${article.html_url}">read more...</a></p>`;
+      div.innerHTML = `<a href="${article.html_url}">${img}<h3>${article.title}</h3><p>${text}...</p></a>`;
       container.appendChild(div);
     });
-    initCarousel("#introductions-carousel", 3);
   } catch (e) {
     // ignore errors
   }
 }
 
 function init() {
-  initCarousel("#company-carousel");
-  const announcementCarousel = document.querySelector(
-    "#announcements-carousel"
-  );
-  if (announcementCarousel) {
-    initCarousel("#announcements-carousel", 3);
-    loadAnnouncementImages();
-  }
+  loadAnnouncements();
   loadIntroductions();
 }
 

--- a/style.css
+++ b/style.css
@@ -1126,7 +1126,7 @@ ul {
 
 /***** Hero component *****/
 .hero {
-  background-image: url($homepage_background_image);
+  background-image: url("");
   background-position: center;
   background-size: cover;
   height: 300px;
@@ -1346,13 +1346,8 @@ ul {
 @media (min-width: 1024px) {
   .intranet-grid {
     grid-template-columns: 2fr 1fr;
-    grid-template-areas: "carousel carousel" "introduction quick-links" "departments announcements" "activity activity";
+    grid-template-areas: "carousel carousel" "introduction quick-links" "departments departments" "activity activity";
   }
-}
-
-/***** Carousel and introduction *****/
-#company-carousel {
-  grid-area: carousel;
 }
 
 /***** Carousel and introduction *****/
@@ -1366,6 +1361,12 @@ ul {
   border-radius: 8px;
   color: $brand_text_color;
 }
+#company-carousel .carousel-item img {
+  width: 100%;
+  height: 200px;
+  object-fit: cover;
+  margin-bottom: 10px;
+}
 #company-carousel .carousel-item.active {
   display: block;
 }
@@ -1376,21 +1377,23 @@ ul {
   margin-bottom: 40px;
 }
 
-#introductions-carousel {
+#introductions-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 20px;
   text-align: center;
 }
-#introductions-carousel .carousel-item {
-  display: none;
-}
-#introductions-carousel .carousel-item.active {
+#introductions-grid .intro-item a {
   display: block;
+  color: inherit;
+  text-decoration: none;
 }
-#introductions-carousel img {
+#introductions-grid .intro-item img {
   max-width: 100%;
   height: auto;
   margin-bottom: 10px;
 }
-#introductions-carousel h3 {
+#introductions-grid .intro-item h3 {
   margin-bottom: 10px;
 }
 
@@ -1427,22 +1430,7 @@ ul {
 }
 
 .announcements {
-  grid-area: announcements;
-}
-
-#announcements-carousel {
-  text-align: center;
-}
-#announcements-carousel .carousel-item {
-  display: none;
-}
-#announcements-carousel .carousel-item.active {
-  display: block;
-}
-#announcements-carousel img {
-  max-width: 100%;
-  height: auto;
-  margin-bottom: 10px;
+  grid-area: carousel;
 }
 
 .activity {
@@ -2443,7 +2431,7 @@ ul {
 
 /***** Community *****/
 .community-hero {
-  background-image: url($community_background_image);
+  background-image: url("");
   margin-bottom: 10px;
 }
 .community-footer {

--- a/styles/_community.scss
+++ b/styles/_community.scss
@@ -1,4 +1,6 @@
 /***** Community *****/
+$community_background_image: '' !default;
+
 .community {
   &-hero {
     background-image: url($community_background_image);

--- a/styles/_hero.scss
+++ b/styles/_hero.scss
@@ -1,4 +1,6 @@
 /***** Hero component *****/
+$homepage_background_image: '' !default;
+
 .hero {
   background-image: url($homepage_background_image);
   background-position: center;

--- a/styles/_home-page.scss
+++ b/styles/_home-page.scss
@@ -53,15 +53,9 @@
     grid-template-areas:
       "carousel carousel"
       "introduction quick-links"
-      "departments announcements"
+      "departments departments"
       "activity activity";
   }
-}
-
-/***** Carousel and introduction *****/
-
-#company-carousel {
-  grid-area: carousel;
 }
 
 /***** Carousel and introduction *****/
@@ -75,6 +69,13 @@
     background: linear-gradient(135deg, $brand_color, zass-lighten($brand_color, 10%));
     border-radius: 8px;
     color: $brand_text_color;
+
+    img {
+      width: 100%;
+      height: 200px;
+      object-fit: cover;
+      margin-bottom: 10px;
+    }
   }
 
   .carousel-item.active {
@@ -88,25 +89,28 @@
   margin-bottom: 40px;
 }
 
-#introductions-carousel {
+#introductions-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 20px;
   text-align: center;
 
-  .carousel-item {
-    display: none;
-  }
+  .intro-item {
+    a {
+      display: block;
+      color: inherit;
+      text-decoration: none;
+    }
 
-  .carousel-item.active {
-    display: block;
-  }
+    img {
+      max-width: 100%;
+      height: auto;
+      margin-bottom: 10px;
+    }
 
-  img {
-    max-width: 100%;
-    height: auto;
-    margin-bottom: 10px;
-  }
-
-  h3 {
-    margin-bottom: 10px;
+    h3 {
+      margin-bottom: 10px;
+    }
   }
 }
 
@@ -144,25 +148,7 @@
 
 .departments { grid-area: departments; }
 
-.announcements { grid-area: announcements; }
-
-#announcements-carousel {
-  text-align: center;
-
-  .carousel-item {
-    display: none;
-  }
-
-  .carousel-item.active {
-    display: block;
-  }
-
-  img {
-    max-width: 100%;
-    height: auto;
-    margin-bottom: 10px;
-  }
-}
+.announcements { grid-area: carousel; }
 
 .activity { grid-area: activity; }
 

--- a/templates/home_page.hbs
+++ b/templates/home_page.hbs
@@ -1,6 +1,5 @@
 <h1 class="visibility-hidden">{{ help_center.name }}</h1>
 
-<div id="main-content" class="container">
 <section class="hero hero--brand">
   <div class="hero-inner">
     <h2>{{ help_center.name }}</h2>
@@ -10,18 +9,16 @@
 </section>
 
 <div id="main-content" class="container intranet-grid">
-<div class="container">
-  <section id="company-carousel" class="carousel section">
-    <script id="carousel-data" type="application/json">
-      {{settings.carousel}}
-    </script>
+  <section class="section announcements">
+    <h2>Announcements</h2>
+    <div id="company-carousel" class="carousel"></div>
   </section>
 
   <section class="section introduction">
     <h2>Welcome to the Company Intranet</h2>
     <p>Stay informed with announcements and explore resources for every department.</p>
-    <h2>Introductions</h2>
-    <div id="introductions-carousel" class="carousel"></div>
+    <h2>New Hires</h2>
+    <div id="introductions-grid" class="introductions-grid"></div>
   </section>
 
   <section class="section departments">
@@ -34,27 +31,6 @@
     </script>
   </section>
 
-  {{#if promoted_articles}}
-  <section class="section announcements">
-    <h2>Announcements</h2>
-    <ul class="article-list promoted-articles">
-      {{#each promoted_articles}}
-        <li class="promoted-articles-item">
-          <a href="{{url}}">
-            {{title}}
-            {{#if internal}}
-              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16" class="icon-lock" title="{{t 'internal'}}">
-                <rect width="12" height="9" x="2" y="7" fill="currentColor" rx="1" ry="1"/>
-                <path fill="none" stroke="currentColor" d="M4.5 7.5V4a3.5 3.5 0 017 0v3.5"/>
-              </svg>
-            {{/if}}
-          </a>
-        </li>
-      {{/each}}
-    </ul>
-  </section>
-  {{/if}}
-
   {{#if help_center.community_enabled}}
     <section class="section home-section community">
       <h2>{{t 'community'}}</h2>
@@ -63,25 +39,7 @@
       {{/link}}
 
       <div class="community-image"></div>
-    <section class="section announcements">
-      <h2>Announcements</h2>
-      <div id="announcements-carousel" class="carousel">
-        {{#each promoted_articles}}
-          <div class="carousel-item" data-article-id="{{id}}">
-            <a href="{{url}}">
-              <img alt="{{title}}" />
-              <span>{{title}}</span>
-              {{#if internal}}
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16" class="icon-lock" title="{{t 'internal'}}">
-                  <rect width="12" height="9" x="2" y="7" fill="currentColor" rx="1" ry="1"/>
-                  <path fill="none" stroke="currentColor" d="M4.5 7.5V4a3.5 3.5 0 017 0v3.5"/>
-                </svg>
-              {{/if}}
-            </a>
-          </div>
-        {{/each}}
-      </div>
     </section>
   {{/if}}
-
 </div>
+


### PR DESCRIPTION
## Summary
- populate top carousel with latest 3 "Announcements" articles
- show 2x2 grid of recent "introductions" articles with image and snippet
- simplify homepage layout and styles
- normalize carousel image sizes and link introduction tiles to their articles

## Testing
- `yarn build`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68b6a8b10d0c83209214e4ababc9501e