### PR TITLE
feat: move article sidebar to right

### DIFF
--- a/style.css
+++ b/style.css
@@ -1712,7 +1712,7 @@ ul {
 }
 @media (min-width: 1024px) {
   .article-container {
-    flex-direction: row;
+    flex-direction: row-reverse;
   }
 }
 .article-header {

--- a/styles/_article.scss
+++ b/styles/_article.scss
@@ -2,8 +2,8 @@
 .article {
   /*
   * The article grid is defined this way to optimize readability:
-  * Sidebar | Content | Free space
-  * 17%     | 66%     | 17%
+  * Free space | Content | Sidebar
+  * 17%        | 66%     | 17%
   */
   @include desktop {
     flex: 1 0 66%;
@@ -16,7 +16,7 @@
 
   &-container {
     @include desktop {
-      flex-direction: row;
+      flex-direction: row-reverse;
     }
 
     display: flex;


### PR DESCRIPTION
## Summary
- reverse article layout so section article list renders on the right

## Testing
- `yarn build` *(fails: rollup: not found)*
- `yarn test` *(fails: jest: not found)*
- `yarn eslint` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b10b3a2083209b309d85d89fee4a