### PR TITLE
feat: redesign intranet page layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -658,67 +658,38 @@
     }
   });
 
-  function initCarousel(selector, limit = Infinity) {
-    const container = document.querySelector(selector);
-    if (!container) return;
-    let slides = Array.from(container.querySelectorAll(".carousel-item"));
-    if (limit !== Infinity) {
-      slides.slice(limit).forEach((slide) => slide.remove());
-      slides = slides.slice(0, limit);
-    }
-    let index = 0;
-    if (slides.length) {
-      slides[0].classList.add("active");
-      setInterval(() => {
-        slides[index].classList.remove("active");
-        index = (index + 1) % slides.length;
-        slides[index].classList.add("active");
-      }, 5000);
-    }
-  }
-
   async function loadAnnouncements() {
-    const container = document.querySelector("#company-carousel");
-    if (!container) return;
+    const list = document.querySelector("#announcement-list");
+    if (!list) return;
     try {
       const resp = await fetch(
-        "/api/v2/help_center/articles.json?label_names=Announcements&per_page=3&sort_by=created_at&sort_order=desc"
+        "/api/v2/help_center/articles.json?label_names=Announcements&per_page=5&sort_by=created_at&sort_order=desc"
       );
       const data = await resp.json();
       data.articles.forEach((article) => {
-        const div = document.createElement("div");
-        div.className = "carousel-item";
-        const match = article.body.match(/<img[^>]+src=\"([^\"]+)\"/i);
-        const img = match ? `<img src="${match[1]}" alt="${article.title}" />` : "";
-        div.innerHTML = `${img}<span>${article.title}</span>`;
-        container.appendChild(div);
+        const li = document.createElement("li");
+        li.className = "announcement-item";
+        li.innerHTML = `<a href="${article.html_url}">${article.title}</a>`;
+        list.appendChild(li);
       });
-      initCarousel("#company-carousel", 3);
     } catch (e) {
       // ignore errors
     }
   }
 
   async function loadIntroductions() {
-    const container = document.querySelector("#introductions-grid");
-    if (!container) return;
+    const list = document.querySelector("#introductions-list");
+    if (!list) return;
     try {
       const resp = await fetch(
-        "/api/v2/help_center/articles.json?label_names=introductions&per_page=4&sort_by=created_at&sort_order=desc"
+        "/api/v2/help_center/articles.json?label_names=introductions&per_page=5&sort_by=created_at&sort_order=desc"
       );
       const data = await resp.json();
       data.articles.forEach((article) => {
-        const div = document.createElement("div");
-        div.className = "intro-item";
-        const match = article.body.match(/<img[^>]+src=\"([^\"]+)\"/i);
-        const img = match ? `<img src="${match[1]}" alt="${article.title}" />` : "";
-        const text = article.body
-          .replace(/<[^>]+>/g, "")
-          .split(/\s+/)
-          .slice(0, 20)
-          .join(" ");
-        div.innerHTML = `<a href="${article.html_url}">${img}<h3>${article.title}</h3><p>${text}...</p></a>`;
-        container.appendChild(div);
+        const li = document.createElement("li");
+        li.className = "introduction-item";
+        li.textContent = article.title;
+        list.appendChild(li);
       });
     } catch (e) {
       // ignore errors
@@ -737,7 +708,7 @@
     if (!list) return;
     const locale = document.documentElement.lang;
     try {
-      const resp = await fetch(`/api/v2/help_center/categories/4961264026655/sections`);
+      const resp = await fetch(`/api/v2/help_center/${locale}/categories/4961264026655/sections.json`);
       const data = await resp.json();
       data.sections.forEach((section) => {
         const li = document.createElement('li');

--- a/src/carousel.js
+++ b/src/carousel.js
@@ -1,64 +1,35 @@
-export function initCarousel(selector, limit = Infinity) {
-  const container = document.querySelector(selector);
-  if (!container) return;
-  let slides = Array.from(container.querySelectorAll(".carousel-item"));
-  if (limit !== Infinity) {
-    slides.slice(limit).forEach((slide) => slide.remove());
-    slides = slides.slice(0, limit);
-  }
-  let index = 0;
-  if (slides.length) {
-    slides[0].classList.add("active");
-    setInterval(() => {
-      slides[index].classList.remove("active");
-      index = (index + 1) % slides.length;
-      slides[index].classList.add("active");
-    }, 5000);
-  }
-}
-
 async function loadAnnouncements() {
-  const container = document.querySelector("#company-carousel");
-  if (!container) return;
+  const list = document.querySelector("#announcement-list");
+  if (!list) return;
   try {
     const resp = await fetch(
-      "/api/v2/help_center/articles.json?label_names=Announcements&per_page=3&sort_by=created_at&sort_order=desc"
+      "/api/v2/help_center/articles.json?label_names=Announcements&per_page=5&sort_by=created_at&sort_order=desc"
     );
     const data = await resp.json();
     data.articles.forEach((article) => {
-      const div = document.createElement("div");
-      div.className = "carousel-item";
-      const match = article.body.match(/<img[^>]+src=\"([^\"]+)\"/i);
-      const img = match ? `<img src="${match[1]}" alt="${article.title}" />` : "";
-      div.innerHTML = `${img}<span>${article.title}</span>`;
-      container.appendChild(div);
+      const li = document.createElement("li");
+      li.className = "announcement-item";
+      li.innerHTML = `<a href="${article.html_url}">${article.title}</a>`;
+      list.appendChild(li);
     });
-    initCarousel("#company-carousel", 3);
   } catch (e) {
     // ignore errors
   }
 }
 
 async function loadIntroductions() {
-  const container = document.querySelector("#introductions-grid");
-  if (!container) return;
+  const list = document.querySelector("#introductions-list");
+  if (!list) return;
   try {
     const resp = await fetch(
-      "/api/v2/help_center/articles.json?label_names=introductions&per_page=4&sort_by=created_at&sort_order=desc"
+      "/api/v2/help_center/articles.json?label_names=introductions&per_page=5&sort_by=created_at&sort_order=desc"
     );
     const data = await resp.json();
     data.articles.forEach((article) => {
-      const div = document.createElement("div");
-      div.className = "intro-item";
-      const match = article.body.match(/<img[^>]+src=\"([^\"]+)\"/i);
-      const img = match ? `<img src="${match[1]}" alt="${article.title}" />` : "";
-      const text = article.body
-        .replace(/<[^>]+>/g, "")
-        .split(/\s+/)
-        .slice(0, 20)
-        .join(" ");
-      div.innerHTML = `<a href="${article.html_url}">${img}<h3>${article.title}</h3><p>${text}...</p></a>`;
-      container.appendChild(div);
+      const li = document.createElement("li");
+      li.className = "introduction-item";
+      li.textContent = article.title;
+      list.appendChild(li);
     });
   } catch (e) {
     // ignore errors

--- a/style.css
+++ b/style.css
@@ -1346,87 +1346,19 @@ ul {
 @media (min-width: 1024px) {
   .intranet-grid {
     grid-template-columns: 2fr 1fr;
-    grid-template-areas: "carousel carousel" "introduction quick-links" "departments departments" "activity activity";
   }
 }
 
-/***** Carousel and introduction *****/
-#company-carousel {
-  text-align: center;
-}
-#company-carousel .carousel-item {
-  display: none;
-  padding: 40px;
-  background: linear-gradient(135deg, $brand_color, lighten($brand_color, 10%));
-  border-radius: 8px;
-  color: $brand_text_color;
-}
-#company-carousel .carousel-item img {
-  width: 100%;
-  height: 200px;
-  object-fit: cover;
-  margin-bottom: 10px;
-}
-#company-carousel .carousel-item.active {
-  display: block;
-}
-
-.introduction {
-  grid-area: introduction;
-  text-align: center;
-  margin-bottom: 40px;
-}
-
-#introductions-grid {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 20px;
-  text-align: center;
-}
-#introductions-grid .intro-item a {
-  display: block;
-  color: inherit;
-  text-decoration: none;
-}
-#introductions-grid .intro-item img {
-  max-width: 100%;
-  height: auto;
-  margin-bottom: 10px;
-}
-#introductions-grid .intro-item h3 {
-  margin-bottom: 10px;
-}
-
-.department-rail {
-  grid-area: quick-links;
-}
-.department-rail-list {
+.announcement-list,
+.introduction-list {
   list-style: none;
+  margin: 0;
   padding: 0;
 }
-.department-rail-item {
-  margin-bottom: 10px;
-}
-.department-rail-item a {
-  display: block;
-  padding: 12px 20px;
-  background: $brand_color;
-  border-radius: 8px;
-  text-decoration: none;
-  font-weight: bold;
-  color: $brand_text_color;
-  transition: background 0.3s;
-}
-.department-rail-item a:hover {
-  background: darken($brand_color, 5%);
-}
 
-.announcements {
-  grid-area: carousel;
-}
-
-.activity {
-  grid-area: activity;
+.announcement-item,
+.introduction-item {
+  margin-bottom: 20px;
 }
 
 /***** Promoted articles *****/

--- a/styles/_home-page.scss
+++ b/styles/_home-page.scss
@@ -50,97 +50,20 @@
 
   @include desktop {
     grid-template-columns: 2fr 1fr;
-    grid-template-areas:
-      "carousel carousel"
-      "introduction quick-links"
-      "departments departments"
-      "activity activity";
   }
 }
 
-/***** Carousel and introduction *****/
-
-#company-carousel {
-  text-align: center;
-
-  .carousel-item {
-    display: none;
-    padding: 40px;
-    background: linear-gradient(135deg, $brand_color, zass-lighten($brand_color, 10%));
-    border-radius: 8px;
-    color: $brand_text_color;
-
-    img {
-      width: 100%;
-      height: 200px;
-      object-fit: cover;
-      margin-bottom: 10px;
-    }
-  }
-
-  .carousel-item.active {
-    display: block;
-  }
+.announcement-list,
+.introduction-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
 }
 
-.introduction {
-  grid-area: introduction;
-  text-align: center;
-  margin-bottom: 40px;
+.announcement-item,
+.introduction-item {
+  margin-bottom: 20px;
 }
-
-#introductions-grid {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 20px;
-  text-align: center;
-
-  .intro-item {
-    a {
-      display: block;
-      color: inherit;
-      text-decoration: none;
-    }
-
-    h3 {
-      margin-bottom: 10px;
-    }
-  }
-}
-
-.department-rail {
-  grid-area: quick-links;
-
-  &-list {
-    list-style: none;
-    padding: 0;
-  }
-
-  &-item {
-    margin-bottom: 10px;
-
-    a {
-      display: block;
-      padding: 12px 20px;
-      background: $brand_color;
-      border-radius: 8px;
-      text-decoration: none;
-      font-weight: bold;
-      color: $brand_text_color;
-      transition: background .3s;
-
-      &:hover {
-        background: zass-darken($brand_color, 5%);
-      }
-    }
-  }
-}
-
-.departments { grid-area: departments; }
-
-.announcements { grid-area: carousel; }
-
-.activity { grid-area: activity; }
 
 /***** Promoted articles *****/
 

--- a/templates/home_page.hbs
+++ b/templates/home_page.hbs
@@ -1,46 +1,13 @@
 <h1 class="visibility-hidden">{{ help_center.name }}</h1>
 
-<section class="hero hero--brand">
-  <div class="hero-inner">
-    <h2>{{ help_center.name }}</h2>
-    <p>Your secure hub for company resources and updates.</p>
-    <a href="#company-carousel" class="btn btn-primary">Explore</a>
-  </div>
-</section>
-
 <div id="main-content" class="container intranet-grid">
-  <section class="section announcements">
-    <h2>Announcements</h2>
-    <div id="company-carousel" class="carousel"></div>
+  <section class="announcements">
+    <h2>Company Announcements</h2>
+    <ul id="announcement-list" class="announcement-list"></ul>
   </section>
 
-  <section class="section introduction">
-    <h2>Welcome to the Company Intranet</h2>
-    <p>Stay informed with announcements and explore resources for every department.</p>
-    <h2>New Hires</h2>
-    <div id="introductions-grid" class="introductions-grid"></div>
-  </section>
-
-  <aside class="section department-rail">
-    <h2>Departments</h2>
-    <section class="blocks">
-      <ul class="blocks-list"></ul>
-    </section>
-    <script id="departments-data" type="application/json">
-      {{settings.departments}}
-    </script>
-  </section>
+  <aside class="introductions">
+    <h2>Introductions</h2>
+    <ul id="introductions-list" class="introduction-list"></ul>
   </aside>
-
-  {{#if help_center.community_enabled}}
-    <section class="section home-section community">
-      <h2>{{t 'community'}}</h2>
-      {{#link 'community' class='community-link'}}
-        {{t 'join_conversation'}}
-      {{/link}}
-
-      <div class="community-image"></div>
-    </section>
-  {{/if}}
 </div>
-


### PR DESCRIPTION
## Summary
- simplify intranet homepage with two-column announcements and introductions layout
- fetch and render announcements and introductions as lists
- streamline styles for new intranet layout

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68b6b1f067d083209a5c0088474b4416