### PR TITLE
fix: render department and introductions lists and widen article content

### DIFF
--- a/script.js
+++ b/script.js
@@ -688,8 +688,10 @@
       data.articles.forEach((article) => {
         const div = document.createElement("div");
         div.className = "carousel-item";
-        const match = article.body.match(/<img[^>]+src=\"([^\"]+)\"/i);
-        const img = match ? `<img src="${match[1]}" alt="${article.title}" />` : "";
+        const match = article.body.match(/<img[^>]+src="([^"]+)"/i);
+        const img = match
+          ? `<img src="${match[1]}" alt="${article.title}" />`
+          : "";
         div.innerHTML = `${img}<span>${article.title}</span>`;
         container.appendChild(div);
       });
@@ -703,15 +705,18 @@
     const container = document.querySelector("#introductions-grid");
     if (!container) return;
     try {
+      const locale = document.documentElement.lang;
       const resp = await fetch(
-        "/api/v2/help_center/articles.json?label_names=introductions&per_page=4&sort_by=created_at&sort_order=desc"
+        `/api/v2/help_center/${locale}/articles.json?label_names=introductions&per_page=100&sort_by=created_at&sort_order=desc`
       );
       const data = await resp.json();
       data.articles.forEach((article) => {
         const div = document.createElement("div");
         div.className = "intro-item";
-        const match = article.body.match(/<img[^>]+src=\"([^\"]+)\"/i);
-        const img = match ? `<img src="${match[1]}" alt="${article.title}" />` : "";
+        const match = article.body.match(/<img[^>]+src="([^"]+)"/i);
+        const img = match
+          ? `<img src="${match[1]}" alt="${article.title}" />`
+          : "";
         const text = article.body
           .replace(/<[^>]+>/g, "")
           .split(/\s+/)
@@ -733,16 +738,18 @@
   document.addEventListener("DOMContentLoaded", init);
 
   async function loadDepartments() {
-    const list = document.querySelector('#department-list');
+    const list = document.querySelector(".department-rail .blocks-list");
     if (!list) return;
     const locale = document.documentElement.lang;
     try {
-      const resp = await fetch(`/api/v2/help_center/categories/4961264026655/sections`);
+      const resp = await fetch(
+        `/api/v2/help_center/${locale}/categories/4961264026655/sections.json`
+      );
       const data = await resp.json();
       data.sections.forEach((section) => {
-        const li = document.createElement('li');
-        li.className = 'department-rail-item';
-        const a = document.createElement('a');
+        const li = document.createElement("li");
+        li.className = "department-rail-item";
+        const a = document.createElement("a");
         a.href = section.html_url;
         a.textContent = section.name;
         li.appendChild(a);
@@ -753,6 +760,6 @@
     }
   }
 
-  document.addEventListener('DOMContentLoaded', loadDepartments);
+  document.addEventListener("DOMContentLoaded", loadDepartments);
 
 })();

--- a/src/carousel.js
+++ b/src/carousel.js
@@ -28,8 +28,10 @@ async function loadAnnouncements() {
     data.articles.forEach((article) => {
       const div = document.createElement("div");
       div.className = "carousel-item";
-      const match = article.body.match(/<img[^>]+src=\"([^\"]+)\"/i);
-      const img = match ? `<img src="${match[1]}" alt="${article.title}" />` : "";
+      const match = article.body.match(/<img[^>]+src="([^"]+)"/i);
+      const img = match
+        ? `<img src="${match[1]}" alt="${article.title}" />`
+        : "";
       div.innerHTML = `${img}<span>${article.title}</span>`;
       container.appendChild(div);
     });
@@ -43,15 +45,18 @@ async function loadIntroductions() {
   const container = document.querySelector("#introductions-grid");
   if (!container) return;
   try {
+    const locale = document.documentElement.lang;
     const resp = await fetch(
-      "/api/v2/help_center/articles.json?label_names=introductions&per_page=4&sort_by=created_at&sort_order=desc"
+      `/api/v2/help_center/${locale}/articles.json?label_names=introductions&per_page=100&sort_by=created_at&sort_order=desc`
     );
     const data = await resp.json();
     data.articles.forEach((article) => {
       const div = document.createElement("div");
       div.className = "intro-item";
-      const match = article.body.match(/<img[^>]+src=\"([^\"]+)\"/i);
-      const img = match ? `<img src="${match[1]}" alt="${article.title}" />` : "";
+      const match = article.body.match(/<img[^>]+src="([^"]+)"/i);
+      const img = match
+        ? `<img src="${match[1]}" alt="${article.title}" />`
+        : "";
       const text = article.body
         .replace(/<[^>]+>/g, "")
         .split(/\s+/)

--- a/src/departments.js
+++ b/src/departments.js
@@ -1,14 +1,16 @@
 async function loadDepartments() {
-  const list = document.querySelector('#department-list');
+  const list = document.querySelector(".department-rail .blocks-list");
   if (!list) return;
   const locale = document.documentElement.lang;
   try {
-    const resp = await fetch(`/api/v2/help_center/${locale}/categories/4961264026655/sections.json`);
+    const resp = await fetch(
+      `/api/v2/help_center/${locale}/categories/4961264026655/sections.json`
+    );
     const data = await resp.json();
     data.sections.forEach((section) => {
-      const li = document.createElement('li');
-      li.className = 'department-rail-item';
-      const a = document.createElement('a');
+      const li = document.createElement("li");
+      li.className = "department-rail-item";
+      const a = document.createElement("a");
       a.href = section.html_url;
       a.textContent = section.name;
       li.appendChild(a);
@@ -19,4 +21,4 @@ async function loadDepartments() {
   }
 }
 
-document.addEventListener('DOMContentLoaded', loadDepartments);
+document.addEventListener("DOMContentLoaded", loadDepartments);

--- a/style.css
+++ b/style.css
@@ -1388,11 +1388,6 @@ ul {
   color: inherit;
   text-decoration: none;
 }
-#introductions-grid .intro-item img {
-  max-width: 100%;
-  height: auto;
-  margin-bottom: 10px;
-}
 #introductions-grid .intro-item h3 {
   margin-bottom: 10px;
 }
@@ -1419,6 +1414,10 @@ ul {
 }
 .department-rail-item a:hover {
   background: darken($brand_color, 5%);
+}
+
+.departments {
+  grid-area: departments;
 }
 
 .announcements {
@@ -1693,15 +1692,15 @@ ul {
 .article {
   /*
   * The article grid is defined this way to optimize readability:
-  * Sidebar | Content | Free space
-  * 17%     | 66%     | 17%
+  * Free space | Content | Sidebar
+  * 8%         | 75%     | 17%
   */
   flex: 1 0 auto;
 }
 @media (min-width: 1024px) {
   .article {
-    flex: 1 0 66%;
-    max-width: 66%;
+    flex: 1 0 75%;
+    max-width: 75%;
     min-width: 640px;
     padding: 0 30px;
   }

--- a/styles/_article.scss
+++ b/styles/_article.scss
@@ -3,11 +3,11 @@
   /*
   * The article grid is defined this way to optimize readability:
   * Free space | Content | Sidebar
-  * 17%        | 66%     | 17%
+  * 8%         | 75%     | 17%
   */
   @include desktop {
-    flex: 1 0 66%;
-    max-width: 66%;
+    flex: 1 0 75%;
+    max-width: 75%;
     min-width: 640px;
     padding: 0 30px;
   }


### PR DESCRIPTION
## Summary
- fix departments list selector and locale fetch
- load all introduction articles from label
- widen article content area on article pages

## Testing
- `yarn eslint src`
- `yarn test`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68b6b2cd38448320b1136c7ce108d5cd