### PR TITLE
fix: display announcements without images

### DIFF
--- a/script.js
+++ b/script.js
@@ -692,20 +692,23 @@
           const title = article.title || "";
           const url = article.html_url || "#";
 
-          if (container) {
-            const div = document.createElement("div");
-            div.className = "carousel-item";
-            const imgUrl = extractFirstImage(body);
-            const imgTag = imgUrl ? `<img src="${imgUrl}" alt="${title}">` : "";
+            if (container) {
+              const div = document.createElement("div");
+              div.className = "carousel-item";
+              const imgUrl = extractFirstImage(body);
 
-            const link = document.createElement("a");
-            link.href = url;
-            link.className = "carousel-link";
-            link.innerHTML = `${imgTag}<span class="carousel-caption">${title}</span>`;
+              const link = document.createElement("a");
+              link.href = url;
+              link.className = "carousel-link";
+              if (imgUrl) {
+                link.innerHTML = `<img src="${imgUrl}" alt="${title}"><span class="carousel-caption">${title}</span>`;
+              } else {
+                link.innerHTML = `<span class="carousel-caption no-image">${title}</span>`;
+              }
 
-            div.appendChild(link);
-            container.appendChild(div);
-          }
+              div.appendChild(link);
+              container.appendChild(div);
+            }
 
           if (list) {
             const li = document.createElement("li");

--- a/src/carousel.js
+++ b/src/carousel.js
@@ -37,12 +37,15 @@
           const div = document.createElement("div");
           div.className = "carousel-item";
           const imgUrl = extractFirstImage(body);
-          const imgTag = imgUrl ? `<img src="${imgUrl}" alt="${title}">` : "";
 
           const link = document.createElement("a");
           link.href = url;
           link.className = "carousel-link";
-          link.innerHTML = `${imgTag}<span class="carousel-caption">${title}</span>`;
+          if (imgUrl) {
+            link.innerHTML = `<img src="${imgUrl}" alt="${title}"><span class="carousel-caption">${title}</span>`;
+          } else {
+            link.innerHTML = `<span class="carousel-caption no-image">${title}</span>`;
+          }
 
           div.appendChild(link);
           container.appendChild(div);

--- a/style.css
+++ b/style.css
@@ -1393,6 +1393,9 @@ ul {
   box-sizing: border-box;
   text-align: center;
 }
+.announcement-carousel .carousel-item .carousel-caption.no-image {
+  position: static;
+}
 .announcement-carousel .carousel-item.active {
   display: block;
 }

--- a/styles/_home-page.scss
+++ b/styles/_home-page.scss
@@ -88,22 +88,25 @@
       object-fit: cover;
     }
 
-    .carousel-caption {
-      position: absolute;
-      left: 0;
-      bottom: 0;
-      width: 100%;
-      padding: 8px 12px;
-      background: rgba(0, 0, 0, 0.6);
-      color: #fff;
-      box-sizing: border-box;
-      text-align: center;
+      .carousel-caption {
+        position: absolute;
+        left: 0;
+        bottom: 0;
+        width: 100%;
+        padding: 8px 12px;
+        background: rgba(0, 0, 0, 0.6);
+        color: #fff;
+        box-sizing: border-box;
+        text-align: center;
+      }
+      .carousel-caption.no-image {
+        position: static;
+      }
     }
-  }
 
-  .carousel-item.active {
-    display: block;
-  }
+    .carousel-item.active {
+      display: block;
+    }
 }
 
 #main-content #introductions-grid {


### PR DESCRIPTION
## Summary
- render announcement captions even when no image is present
- ensure caption is visible by overriding carousel caption positioning

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68b716b10e6c8320b0e5961ed14108a1