### PR TITLE
feat: expand introductions grid layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -1401,7 +1401,12 @@ ul {
 }
 
 #main-content #introductions-grid {
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: 1fr;
+}
+@media (min-width: 1024px) {
+  #main-content #introductions-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
 }
 
 .department-rail h2 {

--- a/styles/_home-page.scss
+++ b/styles/_home-page.scss
@@ -110,7 +110,11 @@
 }
 
 #main-content #introductions-grid {
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: 1fr;
+
+  @include desktop {
+    grid-template-columns: repeat(3, 1fr);
+  }
 }
 
 .department-rail {


### PR DESCRIPTION
## Summary
- adjust introductions grid to 3 columns on desktop and single column on mobile
- compile styles

## Testing
- `yarn eslint` (fails: prettier/prettier in src/carousel.js)
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68b75c6586e883208ca29e54a241cae7