### PR TITLE
feat: add configurable request forms list

### DIFF
--- a/assets/request-forms.json
+++ b/assets/request-forms.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": "it-support",
+    "name": "IT requests",
+    "description": "Raise a request for IT support or hardware."
+  },
+  {
+    "id": "risk-submission",
+    "name": "Risk-Submission Portal",
+    "description": "Submit a risk issue or incident."
+  },
+  {
+    "id": "sales-ops",
+    "name": "Sales Operations",
+    "description": "Ask a question or request help from Sales Ops."
+  }
+]

--- a/src/index.js
+++ b/src/index.js
@@ -8,3 +8,4 @@ import "./forms";
 import "./carousel";
 import "./departments";
 import "./modules/theme-toggle";
+import "./requestFormsList";

--- a/src/requestFormsList.js
+++ b/src/requestFormsList.js
@@ -1,0 +1,27 @@
+window.addEventListener("DOMContentLoaded", () => {
+  const container = document.getElementById("request-form-container");
+  if (!container) {
+    return;
+  }
+
+  const dataUrl = container.dataset.forms;
+
+  fetch(dataUrl)
+    .then((response) => response.json())
+    .then((forms) => {
+      forms.forEach((form) => {
+        const card = document.createElement("div");
+        card.className = "request-form-card";
+        card.innerHTML = `
+          <h3>${form.name}</h3>
+          <p>${form.description}</p>
+          <a href="/forms/${form.id}" class="request-form-link">Open</a>
+        `;
+        container.appendChild(card);
+      });
+    })
+    .catch((error) => {
+      // eslint-disable-next-line no-console
+      console.error("Failed to load request forms:", error);
+    });
+});

--- a/styles/_request_form_list.scss
+++ b/styles/_request_form_list.scss
@@ -1,0 +1,21 @@
+#request-form-container {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 1rem;
+}
+
+.request-form-card {
+  border: 1px solid #ccc;
+  padding: 1rem;
+  border-radius: 4px;
+  background: #fff;
+}
+
+.request-form-card h3 {
+  margin-top: 0;
+}
+
+.request-form-card a {
+  display: inline-block;
+  margin-top: 0.5rem;
+}

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -45,4 +45,5 @@
 @import "upload_dropzone";
 @import "summary";
 @import "service_catalog";
+@import "request_form_list";
 @import "dark";

--- a/templates/request_forms_list_page.hbs
+++ b/templates/request_forms_list_page.hbs
@@ -1,0 +1,2 @@
+<h1 class="page-header">Request Forms</h1>
+<div id="request-form-container" data-forms="{{asset 'request-forms.json'}}"></div>


### PR DESCRIPTION
## Summary
- display request forms via JSON-driven list
- style request form cards

## Testing
- `npm run eslint`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68b761f7de288320a1946e703e5db172