### PR TITLE
fix: align introductions section tiles with homepage

### DIFF
--- a/style.css
+++ b/style.css
@@ -289,16 +289,16 @@ a:hover, a:active, a:focus {
   border: 1px solid #0070f3;
 }
 
+.container {
+  max-width: 1160px;
+  margin: 0 auto;
+  padding: 0 5%;
+}
 @media (min-width: 1160px) {
   .container {
     padding: 0;
     width: 90%;
   }
-}
-.container {
-  max-width: 1160px;
-  margin: 0 auto;
-  padding: 0 5%;
 }
 
 .container-divider {
@@ -312,16 +312,16 @@ ul {
   padding: 0;
 }
 
+.error-page {
+  max-width: 1160px;
+  margin: 0 auto;
+  padding: 0 5%;
+}
 @media (min-width: 1160px) {
   .error-page {
     padding: 0;
     width: 90%;
   }
-}
-.error-page {
-  max-width: 1160px;
-  margin: 0 auto;
-  padding: 0 5%;
 }
 
 .visibility-hidden {
@@ -339,11 +339,6 @@ ul {
 }
 
 /***** Buttons *****/
-@media (min-width: 768px) {
-  .button, .pagination-next-link, .pagination-prev-link, .pagination-first-link, .pagination-last-link, .subscriptions-subscribe button, .requests-table-toolbar .organization-subscribe button, .community-follow button, .article-subscribe button, .section-subscribe button, .split-button button {
-    width: auto;
-  }
-}
 .button, .pagination-next-link, .pagination-prev-link, .pagination-first-link, .pagination-last-link, .subscriptions-subscribe button, .requests-table-toolbar .organization-subscribe button, .community-follow button, .article-subscribe button, .section-subscribe button, .split-button button {
   background-color: transparent;
   border: 1px solid #0070f3;
@@ -362,6 +357,11 @@ ul {
   width: 100%;
   -webkit-touch-callout: none;
 }
+@media (min-width: 768px) {
+  .button, .pagination-next-link, .pagination-prev-link, .pagination-first-link, .pagination-last-link, .subscriptions-subscribe button, .requests-table-toolbar .organization-subscribe button, .community-follow button, .article-subscribe button, .section-subscribe button, .split-button button {
+    width: auto;
+  }
+}
 .button:visited, .pagination-next-link:visited, .pagination-prev-link:visited, .pagination-first-link:visited, .pagination-last-link:visited, .subscriptions-subscribe button:visited, .requests-table-toolbar .organization-subscribe button:visited, .community-follow button:visited, .article-subscribe button:visited, .section-subscribe button:visited, .split-button button:visited {
   color: #0070f3;
 }
@@ -378,11 +378,6 @@ ul {
   cursor: default;
 }
 
-@media (min-width: 768px) {
-  .button-large, .hbs-form input[type=submit] {
-    width: auto;
-  }
-}
 .button-large, .hbs-form input[type=submit] {
   cursor: pointer;
   background-color: #0070f3;
@@ -394,6 +389,11 @@ ul {
   min-width: 190px;
   padding: 0 1.9286em;
   width: 100%;
+}
+@media (min-width: 768px) {
+  .button-large, .hbs-form input[type=submit] {
+    width: auto;
+  }
 }
 .button-large:visited, .hbs-form input[type=submit]:visited {
   color: #fff;
@@ -462,16 +462,16 @@ ul {
 }
 
 /***** Tables *****/
-@media (min-width: 768px) {
-  .table {
-    table-layout: auto;
-  }
-}
 .table {
   width: 100%;
   table-layout: fixed;
   border-collapse: collapse;
   border-spacing: 0;
+}
+@media (min-width: 768px) {
+  .table {
+    table-layout: auto;
+  }
 }
 .table th,
 .table th a {
@@ -483,23 +483,23 @@ ul {
 [dir=rtl] .table th a {
   text-align: right;
 }
-@media (min-width: 768px) {
-  .table tr {
-    display: table-row;
-  }
-}
 .table tr {
   border-bottom: 1px solid #ddd;
   display: block;
   padding: 20px 0;
 }
 @media (min-width: 768px) {
-  .table td {
-    display: table-cell;
+  .table tr {
+    display: table-row;
   }
 }
 .table td {
   display: block;
+}
+@media (min-width: 768px) {
+  .table td {
+    display: table-cell;
+  }
 }
 @media (min-width: 1024px) {
   .table td, .table th {
@@ -620,12 +620,6 @@ ul {
 }
 
 /***** Header *****/
-@media (min-width: 1160px) {
-  .header {
-    padding: 0;
-    width: 90%;
-  }
-}
 .header {
   max-width: 1160px;
   margin: 0 auto;
@@ -635,6 +629,12 @@ ul {
   display: flex;
   height: 71px;
   justify-content: space-between;
+}
+@media (min-width: 1160px) {
+  .header {
+    padding: 0;
+    width: 90%;
+  }
 }
 
 .logo img {
@@ -655,15 +655,15 @@ ul {
   text-decoration: none;
 }
 
-@media (min-width: 768px) {
-  .user-nav {
-    position: relative;
-  }
-}
 .user-nav {
   display: inline-block;
   position: absolute;
   white-space: nowrap;
+}
+@media (min-width: 768px) {
+  .user-nav {
+    position: relative;
+  }
 }
 .user-nav[aria-expanded=true] {
   background-color: #fff;
@@ -709,11 +709,6 @@ ul {
     display: inline-block;
   }
 }
-@media (min-width: 768px) {
-  .nav-wrapper-desktop a {
-    display: inline-block;
-  }
-}
 .nav-wrapper-desktop a {
   border: 0;
   color: #0070f3;
@@ -721,6 +716,11 @@ ul {
   font-size: 14px;
   padding: 0 20px 0 0;
   width: auto;
+}
+@media (min-width: 768px) {
+  .nav-wrapper-desktop a {
+    display: inline-block;
+  }
 }
 [dir=rtl] .nav-wrapper-desktop a {
   padding: 0 0 0 20px;
@@ -868,13 +868,13 @@ ul {
 .user-info {
   display: inline-block;
 }
+.user-info .dropdown-toggle::after {
+  display: none;
+}
 @media (min-width: 768px) {
   .user-info .dropdown-toggle::after {
     display: inline-block;
   }
-}
-.user-info .dropdown-toggle::after {
-  display: none;
 }
 .user-info > button {
   border: 0;
@@ -896,14 +896,14 @@ ul {
   padding-right: 0;
 }
 
+#user #user-name {
+  display: none;
+  font-size: 14px;
+}
 @media (min-width: 768px) {
   #user #user-name {
     display: inline-block;
   }
-}
-#user #user-name {
-  display: none;
-  font-size: 14px;
 }
 #user #user-name:hover {
   text-decoration: underline;
@@ -950,18 +950,18 @@ ul {
 .footer a {
   color: zass-lighten(#222, 20%);
 }
-@media (min-width: 1160px) {
-  .footer-inner {
-    padding: 0;
-    width: 90%;
-  }
-}
 .footer-inner {
   max-width: 1160px;
   margin: 0 auto;
   padding: 0 5%;
   display: flex;
   justify-content: space-between;
+}
+@media (min-width: 1160px) {
+  .footer-inner {
+    padding: 0;
+    width: 90%;
+  }
 }
 .footer-language-selector button {
   color: zass-lighten(#222, 20%);
@@ -974,15 +974,15 @@ ul {
 }
 
 /***** Breadcrumbs *****/
-@media (min-width: 768px) {
-  .breadcrumbs {
-    margin: 0;
-  }
-}
 .breadcrumbs {
   margin: 0 0 15px 0;
   padding: 0;
   display: flex;
+}
+@media (min-width: 768px) {
+  .breadcrumbs {
+    margin: 0;
+  }
 }
 .breadcrumbs li {
   color: zass-lighten(#222, 20%);
@@ -1142,6 +1142,13 @@ ul {
   margin: 0 auto;
 }
 
+.page-header {
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  margin: 10px 0;
+}
 @media (min-width: 768px) {
   .page-header {
     align-items: baseline;
@@ -1151,35 +1158,28 @@ ul {
     margin: 0;
   }
 }
-.page-header {
-  display: flex;
-  flex-direction: column;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  margin: 10px 0;
+.page-header .section-subscribe {
+  flex-shrink: 0;
+  margin-bottom: 10px;
 }
 @media (min-width: 768px) {
   .page-header .section-subscribe {
     margin-bottom: 0;
   }
 }
-.page-header .section-subscribe {
-  flex-shrink: 0;
-  margin-bottom: 10px;
-}
 .page-header h1 {
   flex-grow: 1;
   margin-bottom: 10px;
-}
-@media (min-width: 1024px) {
-  .page-header-description {
-    flex-basis: 100%;
-  }
 }
 .page-header-description {
   font-style: italic;
   margin: 0 0 30px 0;
   word-break: break-word;
+}
+@media (min-width: 1024px) {
+  .page-header-description {
+    flex-basis: 100%;
+  }
 }
 .page-header .icon-lock {
   height: 20px;
@@ -1221,11 +1221,6 @@ ul {
 
 /***** Blocks *****/
 /* Used in Homepage#categories and Community#topics */
-@media (min-width: 768px) {
-  .blocks-list {
-    margin: 0 -15px;
-  }
-}
 .blocks-list {
   display: flex;
   flex-wrap: wrap;
@@ -1234,8 +1229,8 @@ ul {
   padding: 0;
 }
 @media (min-width: 768px) {
-  .blocks-item {
-    margin: 0 15px 30px;
+  .blocks-list {
+    margin: 0 -15px;
   }
 }
 .blocks-item {
@@ -1248,6 +1243,11 @@ ul {
   margin: 0 0 30px;
   max-width: 100%;
   text-align: center;
+}
+@media (min-width: 768px) {
+  .blocks-item {
+    margin: 0 15px 30px;
+  }
 }
 .blocks-item:hover, .blocks-item:focus, .blocks-item:active {
   background-color: #0070f3;
@@ -1337,13 +1337,13 @@ a:hover {
   color: #39FED9;
 }
 
+.section {
+  margin-bottom: 40px;
+}
 @media (min-width: 768px) {
   .section {
     margin-bottom: 60px;
   }
-}
-.section {
-  margin-bottom: 40px;
 }
 
 .home-section h2 {
@@ -1468,9 +1468,14 @@ a:hover {
 #main-content #introductions-grid {
   grid-template-columns: 1fr;
 }
+@media (min-width: 768px) {
+  #main-content #introductions-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
 @media (min-width: 1024px) {
   #main-content #introductions-grid {
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(4, 1fr);
   }
 }
 
@@ -1569,14 +1574,14 @@ a:hover {
   color: #fff;
 }
 .btn.btn-primary:hover {
-  background: rgb(5.2408163265, 149.3632653061, 208.7591836735);
+  background: #0595d1;
 }
 .btn.btn-secondary {
   background: #7BEAFC;
   color: #021F4C;
 }
 .btn.btn-secondary:hover {
-  background: rgb(73.1333333333, 226.0666666667, 250.8666666667);
+  background: #49e2fb;
 }
 
 /***** Forms *****/
@@ -1866,16 +1871,16 @@ button {
   font-size: 16px;
   font-weight: 600;
 }
+.recent-activity-item-parent, .recent-activity-item-link {
+  margin: 6px 0;
+  display: inline-block;
+  width: 100%;
+}
 @media (min-width: 768px) {
   .recent-activity-item-parent, .recent-activity-item-link {
     width: 70%;
     margin: 0;
   }
-}
-.recent-activity-item-parent, .recent-activity-item-link {
-  margin: 6px 0;
-  display: inline-block;
-  width: 100%;
 }
 .recent-activity-item-link {
   font-size: 14px;
@@ -1884,6 +1889,8 @@ button {
 }
 .recent-activity-item-meta {
   color: #222;
+  margin: 15px 0 0 0;
+  float: none;
 }
 @media (min-width: 768px) {
   .recent-activity-item-meta {
@@ -1893,10 +1900,6 @@ button {
   [dir=rtl] .recent-activity-item-meta {
     float: left;
   }
-}
-.recent-activity-item-meta {
-  margin: 15px 0 0 0;
-  float: none;
 }
 .recent-activity-item-time, .recent-activity-item-comment {
   display: inline-block;
@@ -1957,21 +1960,16 @@ button {
   display: flex;
   justify-content: flex-end;
 }
+.category-content {
+  flex: 1;
+  max-width: 100%;
+}
 @media (min-width: 1024px) {
   .category-content {
     flex: 0 0 80%;
   }
 }
-.category-content {
-  flex: 1;
-  max-width: 100%;
-}
 
-@media (min-width: 768px) {
-  .section-tree {
-    flex-direction: row;
-  }
-}
 .section-tree {
   display: flex;
   flex-direction: column;
@@ -1979,13 +1977,18 @@ button {
   justify-content: space-between;
 }
 @media (min-width: 768px) {
-  .section-tree .section {
-    flex: 0 0 45%; /* Two columns for tablet and desktop. Leaving 5% separation between columns */
+  .section-tree {
+    flex-direction: row;
   }
 }
 .section-tree .section {
   flex: initial;
   max-width: 100%;
+}
+@media (min-width: 768px) {
+  .section-tree .section {
+    flex: 0 0 45%; /* Two columns for tablet and desktop. Leaving 5% separation between columns */
+  }
 }
 .section-tree-title {
   margin-bottom: 0;
@@ -2020,14 +2023,14 @@ button {
   display: flex;
   justify-content: flex-end;
 }
+.section-content {
+  flex: 1;
+  max-width: 100%;
+}
 @media (min-width: 1024px) {
   .section-content {
     flex: 0 0 80%;
   }
-}
-.section-content {
-  flex: 1;
-  max-width: 100%;
 }
 .section-list {
   margin: 40px 0;
@@ -2061,9 +2064,19 @@ button {
 /* Introductions grid */
 #introductions-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); /* responsive */
+  grid-template-columns: 1fr;
   gap: 32px;
   text-align: center;
+}
+@media (min-width: 768px) {
+  #introductions-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+@media (min-width: 1024px) {
+  #introductions-grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
 }
 #introductions-grid .intro-item {
   background: #fff;
@@ -2099,6 +2112,7 @@ button {
   * Free space | Content | Sidebar
   * 8%         | 75%     | 17%
   */
+  flex: 1 0 auto;
 }
 @media (min-width: 1024px) {
   .article {
@@ -2108,22 +2122,13 @@ button {
     padding: 0 30px;
   }
 }
-.article {
-  flex: 1 0 auto;
-}
-@media (min-width: 1024px) {
-  .article-container {
-    flex-direction: row-reverse;
-  }
-}
 .article-container {
   display: flex;
   flex-direction: column;
 }
-@media (min-width: 768px) {
-  .article-header {
-    flex-direction: row;
-    margin-top: 0;
+@media (min-width: 1024px) {
+  .article-container {
+    flex-direction: row-reverse;
   }
 }
 .article-header {
@@ -2134,6 +2139,12 @@ button {
   justify-content: space-between;
   margin-bottom: 40px;
   margin-top: 20px;
+}
+@media (min-width: 768px) {
+  .article-header {
+    flex-direction: row;
+    margin-top: 0;
+  }
 }
 .article-avatar {
   margin-right: 10px;
@@ -2156,14 +2167,14 @@ button {
   left: -5px;
   vertical-align: baseline;
 }
+.article [role=button] {
+  flex-shrink: 0; /*Avoid collapsing elements in Safari (https://github.com/philipwalton/flexbugs#1-minimum-content-sizing-of-flex-items-not-honored)*/
+  width: 100%;
+}
 @media (min-width: 768px) {
   .article [role=button] {
     width: auto;
   }
-}
-.article [role=button] {
-  flex-shrink: 0; /*Avoid collapsing elements in Safari (https://github.com/philipwalton/flexbugs#1-minimum-content-sizing-of-flex-items-not-honored)*/
-  width: 100%;
 }
 .article-info {
   max-width: 100%;
@@ -2171,6 +2182,9 @@ button {
 .article-meta {
   display: inline-block;
   vertical-align: middle;
+}
+.article-body {
+  display: flow-root;
 }
 .article-body a {
   color: #10B5F9;
@@ -2181,9 +2195,6 @@ button {
 }
 .article-body a:hover, .article-body a:active, .article-body a:focus {
   color: #39FED9;
-}
-.article-body {
-  display: flow-root;
 }
 .article-body img {
   height: auto;
@@ -2306,6 +2317,13 @@ button {
   width: 18px;
   height: 18px;
 }
+.article-sidebar {
+  border-bottom: 1px solid #ddd;
+  border-top: 1px solid #ddd;
+  flex: 1 0 auto;
+  margin-bottom: 20px;
+  padding: 0;
+}
 @media (min-width: 1024px) {
   .article-sidebar {
     border: 0;
@@ -2314,23 +2332,16 @@ button {
     max-width: 17%;
   }
 }
-.article-sidebar {
-  border-bottom: 1px solid #ddd;
-  border-top: 1px solid #ddd;
-  flex: 1 0 auto;
-  margin-bottom: 20px;
-  padding: 0;
-}
-@media (min-width: 768px) {
-  .article-relatives {
-    flex-direction: row;
-  }
-}
 .article-relatives {
   border-top: 1px solid #ddd;
   display: flex;
   flex-direction: column;
   padding: 20px 0;
+}
+@media (min-width: 768px) {
+  .article-relatives {
+    flex-direction: row;
+  }
 }
 .article-relatives > * {
   flex: 1 0 50%;
@@ -2375,13 +2386,13 @@ button {
 .article-more-questions a:hover, .article-more-questions a:active, .article-more-questions a:focus {
   color: #39FED9;
 }
+.article-return-to-top {
+  border-top: 1px solid #87929D;
+}
 @media (min-width: 1024px) {
   .article-return-to-top {
     display: none;
   }
-}
-.article-return-to-top {
-  border-top: 1px solid #87929D;
 }
 .article-return-to-top a {
   color: #222;
@@ -2530,14 +2541,14 @@ button {
   display: flex;
   position: relative;
 }
+.comment-wrapper.comment-official {
+  border: 1px solid #10B5F9;
+  padding: 40px 20px 20px;
+}
 @media (min-width: 768px) {
   .comment-wrapper.comment-official {
     padding-top: 20px;
   }
-}
-.comment-wrapper.comment-official {
-  border: 1px solid #10B5F9;
-  padding: 40px 20px 20px;
 }
 .comment-info {
   min-width: 0;
@@ -2593,15 +2604,18 @@ button {
 .comment-container {
   width: 100%;
 }
+.comment-form-controls {
+  display: none;
+  margin-top: 10px;
+  text-align: left;
+}
 @media (min-width: 768px) {
   [dir=ltr] .comment-form-controls {
     text-align: right;
   }
 }
-.comment-form-controls {
-  display: none;
-  margin-top: 10px;
-  text-align: left;
+.comment-form-controls input[type=submit] {
+  margin-top: 15px;
 }
 @media (min-width: 1024px) {
   .comment-form-controls input[type=submit] {
@@ -2611,9 +2625,6 @@ button {
     margin-left: 0;
     margin-right: 15px;
   }
-}
-.comment-form-controls input[type=submit] {
-  margin-top: 15px;
 }
 .comment-form-controls input[type=checkbox] {
   margin-right: 5px;
@@ -2639,6 +2650,10 @@ button {
   -webkit-hyphens: auto;
   word-break: break-word;
   word-wrap: break-word;
+  display: flow-root;
+  font-family: "Helvetica Neue", Arial, sans-serif;
+  line-height: 1.6;
+  overflow-x: auto;
 }
 .comment-body a {
   color: #10B5F9;
@@ -2649,9 +2664,6 @@ button {
 }
 .comment-body a:hover, .comment-body a:active, .comment-body a:focus {
   color: #39FED9;
-}
-.comment-body {
-  display: flow-root;
 }
 .comment-body img {
   height: auto;
@@ -2747,11 +2759,6 @@ button {
   color: zass-lighten(#222, 20%);
   font-style: italic;
   padding: 0 15px;
-}
-.comment-body {
-  font-family: "Helvetica Neue", Arial, sans-serif;
-  line-height: 1.6;
-  overflow-x: auto;
 }
 .comment-mark-as-solved {
   display: inline-block;
@@ -2859,13 +2866,13 @@ button {
   font-size: 16px;
 }
 
+.post-to-community {
+  margin-top: 10px;
+}
 @media (min-width: 768px) {
   .post-to-community {
     margin: 0;
   }
-}
-.post-to-community {
-  margin-top: 10px;
 }
 
 /* Community topics grid */
@@ -2879,14 +2886,19 @@ button {
 }
 
 /* Community topic page */
+.topic-header {
+  border-bottom: 1px solid #ddd;
+  font-size: 13px;
+}
 @media (min-width: 768px) {
   .topic-header {
     padding-bottom: 10px;
   }
 }
-.topic-header {
-  border-bottom: 1px solid #ddd;
-  font-size: 13px;
+.topic-header .dropdown {
+  display: block;
+  border-top: 1px solid #ddd;
+  padding: 10px 0;
 }
 @media (min-width: 768px) {
   .topic-header .dropdown {
@@ -2896,11 +2908,6 @@ button {
     padding: 0;
   }
 }
-.topic-header .dropdown {
-  display: block;
-  border-top: 1px solid #ddd;
-  padding: 10px 0;
-}
 
 .no-posts-with-filter {
   margin-top: 20px;
@@ -2908,18 +2915,13 @@ button {
 }
 
 /* Topic, post and user follow button */
-@media (min-width: 768px) {
-  .community-follow {
-    margin-bottom: 0;
-    width: auto;
-  }
-}
 .community-follow {
   margin-bottom: 10px;
   width: 100%;
 }
 @media (min-width: 768px) {
-  .community-follow button {
+  .community-follow {
+    margin-bottom: 0;
     width: auto;
   }
 }
@@ -2928,6 +2930,11 @@ button {
   padding: 0 10px 0 15px;
   position: relative;
   width: 100%;
+}
+@media (min-width: 768px) {
+  .community-follow button {
+    width: auto;
+  }
 }
 .community-follow button:hover {
   background-color: #10B5F9;
@@ -2948,11 +2955,6 @@ button {
   background-color: zass-darken(#0070f3, 20%);
   border-color: zass-darken(#0070f3, 20%);
 }
-@media (min-width: 768px) {
-  .community-follow button::after {
-    position: static;
-  }
-}
 .community-follow button::after {
   border-left: 1px solid #0070f3;
   content: attr(data-follower-count);
@@ -2963,6 +2965,11 @@ button {
   padding-left: 10px;
   position: absolute;
   right: 10px;
+}
+@media (min-width: 768px) {
+  .community-follow button::after {
+    position: static;
+  }
 }
 [dir=rtl] .community-follow button::after {
   border-left: 0;
@@ -2976,12 +2983,6 @@ button {
 .striped-list {
   padding: 0;
 }
-@media (min-width: 768px) {
-  .striped-list-item {
-    align-items: center;
-    flex-direction: row;
-  }
-}
 .striped-list-item {
   align-items: flex-start;
   border-bottom: 1px solid #ddd;
@@ -2989,6 +2990,12 @@ button {
   flex-direction: column;
   justify-content: flex-end;
   padding: 20px 0;
+}
+@media (min-width: 768px) {
+  .striped-list-item {
+    align-items: center;
+    flex-direction: row;
+  }
 }
 .striped-list-info {
   flex: 2;
@@ -3007,13 +3014,6 @@ button {
 .striped-list .meta-group {
   margin: 5px 0;
 }
-@media (min-width: 768px) {
-  .striped-list-count {
-    display: flex;
-    flex: 1;
-    justify-content: space-around;
-  }
-}
 .striped-list-count {
   color: zass-lighten(#222, 20%);
   font-size: 13px;
@@ -3021,8 +3021,10 @@ button {
   text-transform: capitalize;
 }
 @media (min-width: 768px) {
-  .striped-list-count-item::after {
-    display: none;
+  .striped-list-count {
+    display: flex;
+    flex: 1;
+    justify-content: space-around;
   }
 }
 .striped-list-count-item::after {
@@ -3030,17 +3032,22 @@ button {
   display: inline-block;
   padding: 0 5px;
 }
+@media (min-width: 768px) {
+  .striped-list-count-item::after {
+    display: none;
+  }
+}
 .striped-list-count-item:last-child::after {
   display: none;
+}
+.striped-list-number {
+  text-align: center;
 }
 @media (min-width: 768px) {
   .striped-list-number {
     color: #222;
     display: block;
   }
-}
-.striped-list-number {
-  text-align: center;
 }
 
 /***** Status labels *****/
@@ -3104,16 +3111,16 @@ button {
 .status-label-hold {
   background-color: #000;
 }
-@media (max-width: 768px) {
-  .status-label-request {
-    max-width: 150px;
-  }
-}
 .status-label-request {
   max-width: 100%;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+@media (max-width: 768px) {
+  .status-label-request {
+    max-width: 150px;
+  }
 }
 
 /***** Post *****/
@@ -3122,28 +3129,22 @@ button {
 * Content | Sidebar
 * 70%     | 30%
 */
+.post {
+  flex: 1;
+  margin-bottom: 10px;
+}
 @media (min-width: 1024px) {
   .post {
     flex: 1 0 70%;
     max-width: 70%;
   }
 }
-.post {
-  flex: 1;
-  margin-bottom: 10px;
-}
-@media (min-width: 1024px) {
-  .post-container {
-    flex-direction: row;
-  }
-}
 .post-container {
   display: flex;
   flex-direction: column;
 }
-@media (min-width: 768px) {
-  .post-header {
-    align-items: baseline;
+@media (min-width: 1024px) {
+  .post-container {
     flex-direction: row;
   }
 }
@@ -3154,8 +3155,18 @@ button {
   justify-content: space-between;
   margin-bottom: 10px;
 }
+@media (min-width: 768px) {
+  .post-header {
+    align-items: baseline;
+    flex-direction: row;
+  }
+}
 .post-header .status-label {
   vertical-align: super;
+}
+.post-title {
+  margin-bottom: 20px;
+  width: 100%;
 }
 @media (min-width: 768px) {
   .post-title {
@@ -3163,18 +3174,14 @@ button {
     padding-right: 10px;
   }
 }
-.post-title {
-  margin-bottom: 20px;
-  width: 100%;
+.post-title h1 {
+  display: inline;
+  vertical-align: middle;
 }
 @media (min-width: 768px) {
   .post-title h1 {
     margin-right: 5px;
   }
-}
-.post-title h1 {
-  display: inline;
-  vertical-align: middle;
 }
 .post-author {
   align-items: flex-start;
@@ -3212,6 +3219,9 @@ button {
   margin-left: 0;
   margin-right: 10px;
 }
+.post-body {
+  display: flow-root;
+}
 .post-body a {
   color: #10B5F9;
   text-decoration: underline;
@@ -3221,9 +3231,6 @@ button {
 }
 .post-body a:hover, .post-body a:active, .post-body a:focus {
   color: #39FED9;
-}
-.post-body {
-  display: flow-root;
 }
 .post-body img {
   height: auto;
@@ -3340,6 +3347,12 @@ button {
   margin: 5px;
   vertical-align: middle;
 }
+.post-sidebar {
+  border-top: 1px solid #ddd;
+  flex: 1;
+  padding: 30px 0;
+  text-align: center;
+}
 @media (min-width: 1024px) {
   .post-sidebar {
     border: 0;
@@ -3351,23 +3364,17 @@ button {
     padding: 0 50px 0 0;
   }
 }
-.post-sidebar {
-  border-top: 1px solid #ddd;
-  flex: 1;
-  padding: 30px 0;
-  text-align: center;
-}
 .post-sidebar-title {
   font-size: 18px;
   font-weight: 600;
+}
+.post-comments {
+  margin-bottom: 20px;
 }
 @media (min-width: 1024px) {
   .post-comments {
     margin-bottom: 0;
   }
-}
-.post-comments {
-  margin-bottom: 20px;
 }
 
 /***** Community Badges *****/
@@ -3431,32 +3438,27 @@ button {
 }
 
 /* Navigation element that collapses on mobile */
-@media (min-width: 768px) {
-  .collapsible-nav {
-    flex-direction: row;
-  }
-}
 .collapsible-nav {
   flex-direction: column;
   font-size: 14px;
   position: relative;
 }
+@media (min-width: 768px) {
+  .collapsible-nav {
+    flex-direction: row;
+  }
+}
 
+.collapsible-nav-border {
+  border-bottom: 1px solid #ddd;
+  border-top: 1px solid #ddd;
+}
 @media (min-width: 768px) {
   .collapsible-nav-border {
     border-top: 0;
   }
 }
-.collapsible-nav-border {
-  border-bottom: 1px solid #ddd;
-  border-top: 1px solid #ddd;
-}
 
-@media (min-width: 768px) {
-  .collapsible-nav-toggle {
-    display: none;
-  }
-}
 .collapsible-nav-toggle {
   top: 22.5px;
   transform: translateY(-50%);
@@ -3468,6 +3470,11 @@ button {
   width: 25px;
   height: 25px;
   border-radius: 50%;
+}
+@media (min-width: 768px) {
+  .collapsible-nav-toggle {
+    display: none;
+  }
 }
 [dir=rtl] .collapsible-nav-toggle {
   left: 0;
@@ -3487,14 +3494,19 @@ button {
   border: 1px solid #10B5F9;
 }
 
+.collapsible-nav-list {
+  display: flex;
+  flex-direction: column;
+}
 @media (min-width: 768px) {
   .collapsible-nav-list {
     flex-direction: row;
   }
 }
-.collapsible-nav-list {
-  display: flex;
-  flex-direction: column;
+.collapsible-nav-list li {
+  color: #222;
+  line-height: 45px;
+  order: 1;
 }
 @media (min-width: 768px) {
   .collapsible-nav-list li {
@@ -3510,11 +3522,6 @@ button {
     padding: 15px 0;
   }
 }
-.collapsible-nav-list li {
-  color: #222;
-  line-height: 45px;
-  order: 1;
-}
 .collapsible-nav-list li a {
   color: #222;
   display: block;
@@ -3528,20 +3535,25 @@ button {
     text-decoration: none;
   }
 }
+.collapsible-nav-list li:not([aria-selected=true]),
+.collapsible-nav-list li:not(.current) {
+  display: none;
+}
 @media (min-width: 768px) {
   .collapsible-nav-list li:not([aria-selected=true]),
   .collapsible-nav-list li:not(.current) {
     display: block;
   }
 }
-.collapsible-nav-list li:not([aria-selected=true]),
-.collapsible-nav-list li:not(.current) {
-  display: none;
-}
 @media (min-width: 768px) {
   .collapsible-nav-list li[aria-selected=true] {
     padding: 15px 0 11px 0;
   }
+}
+.collapsible-nav-list li[aria-selected=true],
+.collapsible-nav-list li.current {
+  order: 0;
+  position: relative;
 }
 @media (min-width: 768px) {
   .collapsible-nav-list li[aria-selected=true],
@@ -3549,11 +3561,6 @@ button {
     border-bottom: 4px solid #10B5F9;
     order: 1;
   }
-}
-.collapsible-nav-list li[aria-selected=true],
-.collapsible-nav-list li.current {
-  order: 0;
-  position: relative;
 }
 .collapsible-nav-list li[aria-selected=true] a,
 .collapsible-nav-list li.current a {
@@ -3566,12 +3573,6 @@ button {
 }
 
 /* Sidebar navigation that collapses on mobile */
-@media (min-width: 1024px) {
-  .collapsible-sidebar {
-    max-height: none;
-    padding: 0;
-  }
-}
 .collapsible-sidebar {
   flex: 1;
   max-height: 45px;
@@ -3579,13 +3580,14 @@ button {
   padding: 10px 0;
   position: relative;
 }
+@media (min-width: 1024px) {
+  .collapsible-sidebar {
+    max-height: none;
+    padding: 0;
+  }
+}
 .collapsible-sidebar-title {
   margin-top: 0;
-}
-@media (min-width: 1024px) {
-  .collapsible-sidebar-toggle {
-    display: none;
-  }
 }
 .collapsible-sidebar-toggle {
   position: absolute;
@@ -3598,6 +3600,11 @@ button {
   width: 25px;
   height: 25px;
   border-radius: 50%;
+}
+@media (min-width: 1024px) {
+  .collapsible-sidebar-toggle {
+    display: none;
+  }
 }
 [dir=rtl] .collapsible-sidebar-toggle {
   left: 0;
@@ -3616,13 +3623,13 @@ button {
   outline: none;
   border: 1px solid #10B5F9;
 }
+.collapsible-sidebar-body {
+  display: none;
+}
 @media (min-width: 1024px) {
   .collapsible-sidebar-body {
     display: block;
   }
-}
-.collapsible-sidebar-body {
-  display: none;
 }
 .collapsible-sidebar[aria-expanded=true] {
   max-height: none;
@@ -3639,7 +3646,12 @@ button {
 .my-activities-sub-nav {
   margin-bottom: 30px;
 }
-.my-activities-table .striped-list-title { /* My activities tables */ }
+.my-activities-table .striped-list-title { /* My activities tables */
+  display: block;
+  margin-bottom: 10px;
+  max-width: 350px;
+  white-space: normal;
+}
 @media (min-width: 1024px) {
   .my-activities-table .striped-list-title {
     margin-bottom: 0;
@@ -3650,19 +3662,17 @@ button {
     white-space: nowrap;
   }
 }
-.my-activities-table .striped-list-title {
-  display: block;
-  margin-bottom: 10px;
-  max-width: 350px;
-  white-space: normal;
+.my-activities-table thead {
+  display: none;
 }
 @media (min-width: 768px) {
   .my-activities-table thead {
     display: table-header-group;
   }
 }
-.my-activities-table thead {
-  display: none;
+.my-activities-table th:first-child,
+.my-activities-table td:first-child {
+  padding-left: 0;
 }
 @media (min-width: 1024px) {
   .my-activities-table th:first-child,
@@ -3670,39 +3680,38 @@ button {
     width: 500px;
   }
 }
-.my-activities-table th:first-child,
-.my-activities-table td:first-child {
-  padding-left: 0;
-}
 .my-activities-table th:last-child,
 .my-activities-table td:last-child {
   padding-right: 0;
+}
+.my-activities-table td:not(:first-child) {
+  display: none;
 }
 @media (min-width: 768px) {
   .my-activities-table td:not(:first-child) {
     display: table-cell;
   }
 }
-.my-activities-table td:not(:first-child) {
-  display: none;
-}
 
 /* Requests table */
 .requests-search {
   width: 100%;
-}
-@media (min-width: 768px) {
-  .requests-table-toolbar {
-    flex-direction: row;
-  }
 }
 .requests-table-toolbar {
   align-items: flex-end;
   display: flex;
   flex-direction: column;
 }
+@media (min-width: 768px) {
+  .requests-table-toolbar {
+    flex-direction: row;
+  }
+}
 .requests-table-toolbar .search {
   flex: 1;
+  width: 100%;
+}
+.requests-table-toolbar .request-table-filter {
   width: 100%;
 }
 @media (min-width: 768px) {
@@ -3710,8 +3719,8 @@ button {
     width: auto;
   }
 }
-.requests-table-toolbar .request-table-filter {
-  width: 100%;
+.requests-table-toolbar .request-filter {
+  display: block;
 }
 @media (min-width: 768px) {
   .requests-table-toolbar .request-filter {
@@ -3721,17 +3730,19 @@ button {
     margin: 0 30px 0 0;
   }
 }
-.requests-table-toolbar .request-filter {
-  display: block;
+.requests-table-toolbar .request-filter-label {
+  font-size: 13px;
+  margin-top: 30px;
 }
 @media (min-width: 768px) {
   .requests-table-toolbar .request-filter-label {
     margin-top: 0;
   }
 }
-.requests-table-toolbar .request-filter-label {
-  font-size: 13px;
-  margin-top: 30px;
+.requests-table-toolbar select {
+  max-height: 40px;
+  margin-bottom: 30px;
+  width: 100%;
 }
 @media (min-width: 768px) {
   .requests-table-toolbar select {
@@ -3739,11 +3750,6 @@ button {
     max-width: 300px;
     width: auto;
   }
-}
-.requests-table-toolbar select {
-  max-height: 40px;
-  margin-bottom: 30px;
-  width: 100%;
 }
 @media (min-width: 768px) {
   .requests-table-toolbar .organization-subscribe {
@@ -3771,21 +3777,24 @@ button {
 .requests-table-toolbar + .requests {
   margin-top: 40px;
 }
+.requests .requests-table-meta {
+  display: block;
+}
 @media (min-width: 768px) {
   .requests .requests-table-meta {
     display: none;
   }
 }
-.requests .requests-table-meta {
-  display: block;
+.requests .requests-table thead {
+  display: none;
 }
 @media (min-width: 768px) {
   .requests .requests-table thead {
     display: table-header-group;
   }
 }
-.requests .requests-table thead {
-  display: none;
+.requests .requests-table-info {
+  display: block;
 }
 @media (min-width: 768px) {
   .requests .requests-table-info {
@@ -3793,9 +3802,6 @@ button {
     vertical-align: middle;
     width: auto;
   }
-}
-.requests .requests-table-info {
-  display: block;
 }
 .requests .requests-table .requests-link {
   position: relative;
@@ -3813,13 +3819,13 @@ button {
     width: auto;
   }
 }
+.subscriptions-table td:last-child {
+  display: block;
+}
 @media (min-width: 768px) {
   .subscriptions-table td:last-child {
     display: table-cell;
   }
-}
-.subscriptions-table td:last-child {
-  display: block;
 }
 .subscriptions-table td:first-child {
   display: flex;
@@ -3834,6 +3840,10 @@ button {
 }
 
 /* Contributions table */
+.contributions-table td:last-child {
+  color: zass-lighten(#222, 20%);
+  font-size: 13px;
+}
 @media (min-width: 768px) {
   .contributions-table td:last-child {
     color: inherit;
@@ -3841,38 +3851,34 @@ button {
     font-weight: inherit;
   }
 }
-.contributions-table td:last-child {
-  color: zass-lighten(#222, 20%);
-  font-size: 13px;
-}
 
 .no-activities {
   color: zass-lighten(#222, 20%);
 }
 
 /***** Request *****/
-@media (min-width: 1024px) {
-  .request-container {
-    align-items: flex-start;
-    flex-direction: row;
-  }
-}
 .request-container {
   display: flex;
   flex-direction: column;
   flex-wrap: wrap;
   justify-content: space-between;
 }
+@media (min-width: 1024px) {
+  .request-container {
+    align-items: flex-start;
+    flex-direction: row;
+  }
+}
 .request-container .comment-container {
   min-width: 0;
+}
+.request-breadcrumbs {
+  margin-bottom: 40px;
 }
 @media (min-width: 1024px) {
   .request-breadcrumbs {
     margin-bottom: 60px;
   }
-}
-.request-breadcrumbs {
-  margin-bottom: 40px;
 }
 .request-main {
   flex: 1 0 auto;
@@ -3935,6 +3941,9 @@ button {
 .request-main input#mark_as_solved {
   display: none;
 }
+.request-title {
+  width: 100%;
+}
 @media (min-width: 1024px) {
   .request-title {
     border-bottom: 1px solid #ddd;
@@ -3943,8 +3952,11 @@ button {
     padding-bottom: 20px;
   }
 }
-.request-title {
-  width: 100%;
+.request-sidebar {
+  border-bottom: 1px solid #ddd;
+  border-top: 1px solid #ddd;
+  flex: 1 0 auto;
+  order: 0;
 }
 @media (min-width: 1024px) {
   .request-sidebar {
@@ -3956,21 +3968,15 @@ button {
     width: 30%;
   }
 }
-.request-sidebar {
-  border-bottom: 1px solid #ddd;
-  border-top: 1px solid #ddd;
-  flex: 1 0 auto;
-  order: 0;
+.request-sidebar h2 {
+  font-size: 15px;
+  font-weight: 600;
+  position: relative;
 }
 @media (min-width: 1024px) {
   .request-sidebar h2 {
     display: none;
   }
-}
-.request-sidebar h2 {
-  font-size: 15px;
-  font-weight: 600;
-  position: relative;
 }
 .request-details {
   border-bottom: 1px solid #ddd;
@@ -4687,11 +4693,6 @@ button {
 }
 
 /***** Search results *****/
-@media (min-width: 1024px) {
-  .search-results {
-    flex-direction: row;
-  }
-}
 .search-results {
   display: flex;
   flex-direction: column;
@@ -4699,12 +4700,17 @@ button {
   justify-content: space-between;
 }
 @media (min-width: 1024px) {
-  .search-results-column {
-    flex: 0 0 75%;
+  .search-results {
+    flex-direction: row;
   }
 }
 .search-results-column {
   flex: 1;
+}
+@media (min-width: 1024px) {
+  .search-results-column {
+    flex: 0 0 75%;
+  }
 }
 .search-results-sidebar {
   border-top: 1px solid #ddd;
@@ -5223,6 +5229,9 @@ zd-summary-block {
   border-right-color: #859fa1;
 }
 
+.service-catalog-description {
+  display: flow-root;
+}
 .service-catalog-description a {
   color: #10B5F9;
   text-decoration: underline;
@@ -5232,9 +5241,6 @@ zd-summary-block {
 }
 .service-catalog-description a:hover, .service-catalog-description a:active, .service-catalog-description a:focus {
   color: #39FED9;
-}
-.service-catalog-description {
-  display: flow-root;
 }
 .service-catalog-description img {
   height: auto;

--- a/styles/_home-page.scss
+++ b/styles/_home-page.scss
@@ -188,8 +188,12 @@ a {
 #main-content #introductions-grid {
   grid-template-columns: 1fr;
 
+  @include tablet {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
   @include desktop {
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(4, 1fr);
   }
 }
 

--- a/styles/_section.scss
+++ b/styles/_section.scss
@@ -57,9 +57,17 @@
 /* Introductions grid */
 #introductions-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); /* responsive */
+  grid-template-columns: 1fr;
   gap: 32px;
   text-align: center;
+
+  @include tablet {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  @include desktop {
+    grid-template-columns: repeat(4, 1fr);
+  }
 
   .intro-item {
     background: #fff;

--- a/templates/section_page.hbs
+++ b/templates/section_page.hbs
@@ -42,23 +42,23 @@
 
       {{#if section.articles}}
         {{#if (eq section.id "4964692123039")}}
-          <div class="introductions-grid">
+          <div id="introductions-grid">
             {{#each section.articles}}
-              <div class="introduction-item">
-                <a href="{{url}}" class="introduction-link">
+              <div class="intro-item">
+                <a href="{{url}}">
                   {{#if image_url}}
-                    <img src="{{image_url}}" alt="{{title}}" class="introduction-image" />
+                    <img src="{{image_url}}" alt="{{title}}" />
                   {{else}}
-                    <img src="/assets/Image_not_available.png" alt="No image available" class="introduction-image" />
+                    <img src="/assets/Image_not_available.png" alt="No image available" />
                   {{/if}}
-                  <div class="introduction-title">{{title}}</div>
-                  <div class="introduction-body">
+                  <h3>{{title}}</h3>
+                  <p>
                     {{#if body}}
                       {{truncate body 120}}
                     {{else}}
                       <span class="text-muted">No description available.</span>
                     {{/if}}
-                  </div>
+                  </p>
                 </a>
               </div>
             {{/each}}


### PR DESCRIPTION
## Summary
- display introductions section articles in tile grid with images and excerpts
- use responsive CSS grid with four columns on desktop
- update home page grid to match new layout

## Testing
- `npx sass styles/index.scss style.css`
- `yarn build` *(fails: "default" is not exported by "src/Dropdown.js")*
- `yarn eslint` *(fails: Prettier formatting errors in existing files)*
- `yarn test` *(fails: Dropdown tests report constructor errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b867845b488320ad2c67b257a469e0