### PR TITLE
fix: remove home-page check for introductions grid

### DIFF
--- a/script.js
+++ b/script.js
@@ -780,9 +780,6 @@
   // Fetches and renders a 3x2 grid of introductions on the homepage
 
   async function renderIntroductionsGrid() {
-    // Only run on the homepage
-    if (!document.body.classList.contains('home-page')) return;
-
     const container = document.getElementById('introductions-grid');
     if (!container) return;
 

--- a/src/introductions.js
+++ b/src/introductions.js
@@ -2,9 +2,6 @@
 // Fetches and renders a 3x2 grid of introductions on the homepage
 
 export async function renderIntroductionsGrid() {
-  // Only run on the homepage
-  if (!document.body.classList.contains('home-page')) return;
-
   const container = document.getElementById('introductions-grid');
   if (!container) return;
 


### PR DESCRIPTION
## Summary
- render introductions grid whenever `#introductions-grid` exists instead of requiring a `home-page` body class

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf45df2ff883208ee1c4b021c46d33