### PR TITLE
feat: list ticket forms on new request page

### DIFF
--- a/script.js
+++ b/script.js
@@ -506,18 +506,20 @@
       return;
     }
 
-    const dataUrl = container.dataset.forms;
+    const dataUrl = container.dataset.forms || "/api/v2/ticket_forms.json";
 
     fetch(dataUrl)
       .then((response) => response.json())
-      .then((forms) => {
+      .then((data) => {
+        const forms = data.ticket_forms || data.forms || [];
         forms.forEach((form) => {
           const card = document.createElement("div");
           card.className = "request-form-card";
+          const description = form.description ? `<p>${form.description}</p>` : "";
           card.innerHTML = `
           <h3>${form.name}</h3>
-          <p>${form.description}</p>
-          <a href="/forms/${form.id}" class="request-form-link">Open</a>
+          ${description}
+          <a href="${window.location.pathname}?ticket_form_id=${form.id}" class="request-form-link">Open</a>
         `;
           container.appendChild(card);
         });

--- a/src/requestFormsList.js
+++ b/src/requestFormsList.js
@@ -4,18 +4,20 @@ window.addEventListener("DOMContentLoaded", () => {
     return;
   }
 
-  const dataUrl = container.dataset.forms;
+  const dataUrl = container.dataset.forms || "/api/v2/ticket_forms.json";
 
   fetch(dataUrl)
     .then((response) => response.json())
-    .then((forms) => {
+    .then((data) => {
+      const forms = data.ticket_forms || data.forms || [];
       forms.forEach((form) => {
         const card = document.createElement("div");
         card.className = "request-form-card";
+        const description = form.description ? `<p>${form.description}</p>` : "";
         card.innerHTML = `
           <h3>${form.name}</h3>
-          <p>${form.description}</p>
-          <a href="/forms/${form.id}" class="request-form-link">Open</a>
+          ${description}
+          <a href="${window.location.pathname}?ticket_form_id=${form.id}" class="request-form-link">Open</a>
         `;
         container.appendChild(card);
       });

--- a/templates/new_request_page.hbs
+++ b/templates/new_request_page.hbs
@@ -16,14 +16,17 @@
     </h1>
 
     <div id="main-content" class="form">
-        <div id="new-request-form"></div>
+        <div id="request-form-container" hidden></div>
+        <div id="new-request-form" hidden></div>
     </div>
 </div>
 
 <script type="module">
   import { renderNewRequestForm } from "new-request-form";
 
-  const container = document.getElementById("new-request-form");
+  const formContainer = document.getElementById("new-request-form");
+  const listContainer = document.getElementById("request-form-container");
+  const hasFormId = new URLSearchParams(window.location.search).has("ticket_form_id");
 
   const settings = {{json settings}};
 
@@ -50,5 +53,12 @@
     },
   };
 
-  renderNewRequestForm(settings, props, container);
+  if (hasFormId) {
+    listContainer.remove();
+    formContainer.hidden = false;
+    renderNewRequestForm(settings, props, formContainer);
+  } else {
+    formContainer.remove();
+    listContainer.hidden = false;
+  }
 </script>


### PR DESCRIPTION
## Summary
- show list of ticket forms when no form selected on `/requests/new`
- fetch ticket forms dynamically and link to each form

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68bfe62cd6a88320936a76e91f19caac