### PR TITLE
feat: list ticket forms on new request page

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -321,6 +321,251 @@
       ]
     },
     {
+      "label": "Request form tiles",
+      "variables": [
+        {
+          "identifier": "request_form_1_id",
+          "type": "text",
+          "label": "Request form 1 ID",
+          "value": ""
+        },
+        {
+          "identifier": "request_form_1_name",
+          "type": "text",
+          "label": "Request form 1 name",
+          "value": ""
+        },
+        {
+          "identifier": "request_form_1_description",
+          "type": "text",
+          "label": "Request form 1 description",
+          "value": ""
+        },
+        {
+          "identifier": "request_form_1_section",
+          "type": "text",
+          "label": "Request form 1 section",
+          "value": ""
+        },
+        {
+          "identifier": "request_form_2_id",
+          "type": "text",
+          "label": "Request form 2 ID",
+          "value": ""
+        },
+        {
+          "identifier": "request_form_2_name",
+          "type": "text",
+          "label": "Request form 2 name",
+          "value": ""
+        },
+        {
+          "identifier": "request_form_2_description",
+          "type": "text",
+          "label": "Request form 2 description",
+          "value": ""
+        },
+        {
+          "identifier": "request_form_2_section",
+          "type": "text",
+          "label": "Request form 2 section",
+          "value": ""
+        },
+        {
+          "identifier": "request_form_3_id",
+          "type": "text",
+          "label": "Request form 3 ID",
+          "value": ""
+        },
+        {
+          "identifier": "request_form_3_name",
+          "type": "text",
+          "label": "Request form 3 name",
+          "value": ""
+        },
+        {
+          "identifier": "request_form_3_description",
+          "type": "text",
+          "label": "Request form 3 description",
+          "value": ""
+        },
+        {
+          "identifier": "request_form_3_section",
+          "type": "text",
+          "label": "Request form 3 section",
+          "value": ""
+        },
+        {
+          "identifier": "request_form_4_id",
+          "type": "text",
+          "label": "Request form 4 ID",
+          "value": ""
+        },
+        {
+          "identifier": "request_form_4_name",
+          "type": "text",
+          "label": "Request form 4 name",
+          "value": ""
+        },
+        {
+          "identifier": "request_form_4_description",
+          "type": "text",
+          "label": "Request form 4 description",
+          "value": ""
+        },
+        {
+          "identifier": "request_form_4_section",
+          "type": "text",
+          "label": "Request form 4 section",
+          "value": ""
+        },
+        {
+          "identifier": "request_form_5_id",
+          "type": "text",
+          "label": "Request form 5 ID",
+          "value": ""
+        },
+        {
+          "identifier": "request_form_5_name",
+          "type": "text",
+          "label": "Request form 5 name",
+          "value": ""
+        },
+        {
+          "identifier": "request_form_5_description",
+          "type": "text",
+          "label": "Request form 5 description",
+          "value": ""
+        },
+        {
+          "identifier": "request_form_5_section",
+          "type": "text",
+          "label": "Request form 5 section",
+          "value": ""
+        },
+        {
+          "identifier": "request_form_6_id",
+          "type": "text",
+          "label": "Request form 6 ID",
+          "value": ""
+        },
+        {
+          "identifier": "request_form_6_name",
+          "type": "text",
+          "label": "Request form 6 name",
+          "value": ""
+        },
+        {
+          "identifier": "request_form_6_description",
+          "type": "text",
+          "label": "Request form 6 description",
+          "value": ""
+        },
+        {
+          "identifier": "request_form_6_section",
+          "type": "text",
+          "label": "Request form 6 section",
+          "value": ""
+        },
+        {
+          "identifier": "request_form_7_id",
+          "type": "text",
+          "label": "Request form 7 ID",
+          "value": ""
+        },
+        {
+          "identifier": "request_form_7_name",
+          "type": "text",
+          "label": "Request form 7 name",
+          "value": ""
+        },
+        {
+          "identifier": "request_form_7_description",
+          "type": "text",
+          "label": "Request form 7 description",
+          "value": ""
+        },
+        {
+          "identifier": "request_form_7_section",
+          "type": "text",
+          "label": "Request form 7 section",
+          "value": ""
+        },
+        {
+          "identifier": "request_form_8_id",
+          "type": "text",
+          "label": "Request form 8 ID",
+          "value": ""
+        },
+        {
+          "identifier": "request_form_8_name",
+          "type": "text",
+          "label": "Request form 8 name",
+          "value": ""
+        },
+        {
+          "identifier": "request_form_8_description",
+          "type": "text",
+          "label": "Request form 8 description",
+          "value": ""
+        },
+        {
+          "identifier": "request_form_8_section",
+          "type": "text",
+          "label": "Request form 8 section",
+          "value": ""
+        },
+        {
+          "identifier": "request_form_9_id",
+          "type": "text",
+          "label": "Request form 9 ID",
+          "value": ""
+        },
+        {
+          "identifier": "request_form_9_name",
+          "type": "text",
+          "label": "Request form 9 name",
+          "value": ""
+        },
+        {
+          "identifier": "request_form_9_description",
+          "type": "text",
+          "label": "Request form 9 description",
+          "value": ""
+        },
+        {
+          "identifier": "request_form_9_section",
+          "type": "text",
+          "label": "Request form 9 section",
+          "value": ""
+        },
+        {
+          "identifier": "request_form_10_id",
+          "type": "text",
+          "label": "Request form 10 ID",
+          "value": ""
+        },
+        {
+          "identifier": "request_form_10_name",
+          "type": "text",
+          "label": "Request form 10 name",
+          "value": ""
+        },
+        {
+          "identifier": "request_form_10_description",
+          "type": "text",
+          "label": "Request form 10 description",
+          "value": ""
+        },
+        {
+          "identifier": "request_form_10_section",
+          "type": "text",
+          "label": "Request form 10 section",
+          "value": ""
+        }
+      ]
+    },
+    {
       "label": "request_list_group_label",
       "variables": [
         {

--- a/script.js
+++ b/script.js
@@ -506,20 +506,59 @@
       return;
     }
 
-    const dataUrl = container.dataset.forms;
+    const dataUrl = container.dataset.forms || "/api/v2/ticket_forms.json";
+    const settings = JSON.parse(container.dataset.settings || "{}");
+    const formSettings = {};
+    for (let i = 1; i <= 10; i += 1) {
+      const id = settings[`request_form_${i}_id`];
+      if (!id) continue;
+      formSettings[id] = {
+        name: settings[`request_form_${i}_name`],
+        description: settings[`request_form_${i}_description`],
+        section: settings[`request_form_${i}_section`] || "Other",
+      };
+    }
 
     fetch(dataUrl)
       .then((response) => response.json())
-      .then((forms) => {
+      .then((data) => {
+        const forms = data.ticket_forms || data.forms || [];
+        const sections = {};
         forms.forEach((form) => {
-          const card = document.createElement("div");
-          card.className = "request-form-card";
-          card.innerHTML = `
-          <h3>${form.name}</h3>
-          <p>${form.description}</p>
-          <a href="/forms/${form.id}" class="request-form-link">Open</a>
-        `;
-          container.appendChild(card);
+          const override = formSettings[form.id] || {};
+          const name = override.name || form.name;
+          const description = override.description || form.description || "";
+          const section = override.section || "Other";
+          if (!sections[section]) {
+            sections[section] = [];
+          }
+          sections[section].push({ id: form.id, name, description });
+        });
+
+        Object.keys(sections).forEach((sectionName) => {
+          const sectionEl = document.createElement("section");
+          sectionEl.className = "request-form-section";
+          const titleEl = document.createElement("h2");
+          titleEl.className = "request-form-section-title";
+          titleEl.textContent = sectionName;
+          sectionEl.appendChild(titleEl);
+
+          const formsContainer = document.createElement("div");
+          formsContainer.className = "request-form-section-forms";
+          sections[sectionName].forEach((f) => {
+            const card = document.createElement("div");
+            card.className = "request-form-card";
+            const desc = f.description ? `<p>${f.description}</p>` : "";
+            card.innerHTML = `
+            <h3>${f.name}</h3>
+            ${desc}
+            <a href="${window.location.pathname}?ticket_form_id=${f.id}" class="request-form-link">Open</a>
+          `;
+            formsContainer.appendChild(card);
+          });
+
+          sectionEl.appendChild(formsContainer);
+          container.appendChild(sectionEl);
         });
       })
       .catch((error) => {

--- a/src/requestFormsList.js
+++ b/src/requestFormsList.js
@@ -4,20 +4,59 @@ window.addEventListener("DOMContentLoaded", () => {
     return;
   }
 
-  const dataUrl = container.dataset.forms;
+  const dataUrl = container.dataset.forms || "/api/v2/ticket_forms.json";
+  const settings = JSON.parse(container.dataset.settings || "{}");
+  const formSettings = {};
+  for (let i = 1; i <= 10; i += 1) {
+    const id = settings[`request_form_${i}_id`];
+    if (!id) continue;
+    formSettings[id] = {
+      name: settings[`request_form_${i}_name`],
+      description: settings[`request_form_${i}_description`],
+      section: settings[`request_form_${i}_section`] || "Other",
+    };
+  }
 
   fetch(dataUrl)
     .then((response) => response.json())
-    .then((forms) => {
+    .then((data) => {
+      const forms = data.ticket_forms || data.forms || [];
+      const sections = {};
       forms.forEach((form) => {
-        const card = document.createElement("div");
-        card.className = "request-form-card";
-        card.innerHTML = `
-          <h3>${form.name}</h3>
-          <p>${form.description}</p>
-          <a href="/forms/${form.id}" class="request-form-link">Open</a>
-        `;
-        container.appendChild(card);
+        const override = formSettings[form.id] || {};
+        const name = override.name || form.name;
+        const description = override.description || form.description || "";
+        const section = override.section || "Other";
+        if (!sections[section]) {
+          sections[section] = [];
+        }
+        sections[section].push({ id: form.id, name, description });
+      });
+
+      Object.keys(sections).forEach((sectionName) => {
+        const sectionEl = document.createElement("section");
+        sectionEl.className = "request-form-section";
+        const titleEl = document.createElement("h2");
+        titleEl.className = "request-form-section-title";
+        titleEl.textContent = sectionName;
+        sectionEl.appendChild(titleEl);
+
+        const formsContainer = document.createElement("div");
+        formsContainer.className = "request-form-section-forms";
+        sections[sectionName].forEach((f) => {
+          const card = document.createElement("div");
+          card.className = "request-form-card";
+          const desc = f.description ? `<p>${f.description}</p>` : "";
+          card.innerHTML = `
+            <h3>${f.name}</h3>
+            ${desc}
+            <a href="${window.location.pathname}?ticket_form_id=${f.id}" class="request-form-link">Open</a>
+          `;
+          formsContainer.appendChild(card);
+        });
+
+        sectionEl.appendChild(formsContainer);
+        container.appendChild(sectionEl);
       });
     })
     .catch((error) => {

--- a/style.css
+++ b/style.css
@@ -5572,6 +5572,16 @@ zd-summary-block {
 }
 
 #request-form-container {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.request-form-section-title {
+  margin: 0 0 0.5rem;
+}
+
+.request-form-section-forms {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
   gap: 1rem;

--- a/styles/_request_form_list.scss
+++ b/styles/_request_form_list.scss
@@ -1,4 +1,14 @@
 #request-form-container {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.request-form-section-title {
+  margin: 0 0 0.5rem;
+}
+
+.request-form-section-forms {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
   gap: 1rem;

--- a/templates/new_request_page.hbs
+++ b/templates/new_request_page.hbs
@@ -16,16 +16,20 @@
     </h1>
 
     <div id="main-content" class="form">
-        <div id="new-request-form"></div>
+        <div id="request-form-container" hidden></div>
+        <div id="new-request-form" hidden></div>
     </div>
 </div>
 
 <script type="module">
   import { renderNewRequestForm } from "new-request-form";
 
-  const container = document.getElementById("new-request-form");
+  const formContainer = document.getElementById("new-request-form");
+  const listContainer = document.getElementById("request-form-container");
+  const hasFormId = new URLSearchParams(window.location.search).has("ticket_form_id");
 
   const settings = {{json settings}};
+  listContainer.dataset.settings = JSON.stringify(settings);
 
   const props = {
     requestForm: {{json new_request_form}},
@@ -50,5 +54,12 @@
     },
   };
 
-  renderNewRequestForm(settings, props, container);
+  if (hasFormId) {
+    listContainer.remove();
+    formContainer.hidden = false;
+    renderNewRequestForm(settings, props, formContainer);
+  } else {
+    formContainer.remove();
+    listContainer.hidden = false;
+  }
 </script>


### PR DESCRIPTION
## Summary
- show list of ticket forms when no form selected on `/requests/new`
- fetch ticket forms dynamically and link to each form
- categorize ticket forms into themed sections with custom names and descriptions

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68bfe62cd6a88320936a76e91f19caac