### PR TITLE
feat: preset subject and description for user request forms

### DIFF
--- a/script.js
+++ b/script.js
@@ -413,6 +413,53 @@
     ) {
       notificationElm.previousElementSibling.focus();
     }
+
+    // Prefill and hide subject/description for specific ticket forms
+    const formId = document
+      .querySelector("form[data-ticket-form-id]")
+      ?.getAttribute("data-ticket-form-id");
+
+    const subjectMap = {
+      4959432829215: "New User Request",
+      4959424709919: "User Deactivation Request",
+    };
+
+    const descriptionMap = {
+      4959432829215:
+        "New user request, please review the information submitted in the form and then action accordingly",
+      4959424709919:
+        "User deactivation request, please review the information submitted in the form and then action accordingly",
+    };
+
+    if (formId && subjectMap[formId]) {
+      const subjectInput = document.querySelector('[name="request_subject"]');
+      const descriptionInput = document.querySelector(
+        '[name="request_description"]'
+      );
+
+      // Hide subject and description fields
+      if (subjectInput)
+        subjectInput
+          .closest(".form-field, .form-group, .form-control, label")
+          ?.style.setProperty("display", "none", "important");
+      if (descriptionInput)
+        descriptionInput
+          .closest(".form-field, .form-group, .form-control, label")
+          ?.style.setProperty("display", "none", "important");
+
+      // On form submit, prefill subject and description
+      const requestForm = document.querySelector("form[data-ticket-form-id]");
+      if (requestForm) {
+        requestForm.addEventListener(
+          "submit",
+          function () {
+            if (subjectInput) subjectInput.value = subjectMap[formId];
+            if (descriptionInput) descriptionInput.value = descriptionMap[formId];
+          },
+          true
+        );
+      }
+    }
   });
 
   // Carousel module: fetches and renders tiles based on theme setting

--- a/src/forms.js
+++ b/src/forms.js
@@ -166,29 +166,50 @@ window.addEventListener("DOMContentLoaded", () => {
     notificationElm.previousElementSibling.focus();
   }
 
-  // Prefill and hide subject/description for specific ticket form
-  const formId = document.querySelector('form[data-ticket-form-id]')?.getAttribute('data-ticket-form-id');
-  if (formId === '4959432829215') {
-    const firstNameInput = document.querySelector('[name="request_custom_fields_first_name"]');
-    const lastNameInput = document.querySelector('[name="request_custom_fields_last_name"]');
+  // Prefill and hide subject/description for specific ticket forms
+  const formId = document
+    .querySelector("form[data-ticket-form-id]")
+    ?.getAttribute("data-ticket-form-id");
+
+  const subjectMap = {
+    4959432829215: "New User Request",
+    4959424709919: "User Deactivation Request",
+  };
+
+  const descriptionMap = {
+    4959432829215:
+      "New user request, please review the information submitted in the form and then action accordingly",
+    4959424709919:
+      "User deactivation request, please review the information submitted in the form and then action accordingly",
+  };
+
+  if (formId && subjectMap[formId]) {
     const subjectInput = document.querySelector('[name="request_subject"]');
-    const descriptionInput = document.querySelector('[name="request_description"]');
+    const descriptionInput = document.querySelector(
+      '[name="request_description"]'
+    );
 
     // Hide subject and description fields
-    if (subjectInput) subjectInput.closest('.form-field, .form-group, .form-control, label')?.style.setProperty('display', 'none', 'important');
-    if (descriptionInput) descriptionInput.closest('.form-field, .form-group, .form-control, label')?.style.setProperty('display', 'none', 'important');
+    if (subjectInput)
+      subjectInput
+        .closest(".form-field, .form-group, .form-control, label")
+        ?.style.setProperty("display", "none", "important");
+    if (descriptionInput)
+      descriptionInput
+        .closest(".form-field, .form-group, .form-control, label")
+        ?.style.setProperty("display", "none", "important");
 
     // On form submit, prefill subject and description
-    const requestForm = document.querySelector('form[data-ticket-form-id]');
+    const requestForm = document.querySelector("form[data-ticket-form-id]");
     if (requestForm) {
-      requestForm.addEventListener('submit', function(e) {
-        if (firstNameInput && lastNameInput && subjectInput) {
-          subjectInput.value = `${firstNameInput.value} ${lastNameInput.value}`.trim();
-        }
-        if (descriptionInput) {
-          descriptionInput.value = `Submitted by: ${firstNameInput?.value || ''} ${lastNameInput?.value || ''}`.trim();
-        }
-      }, true);
+      requestForm.addEventListener(
+        "submit",
+        function () {
+          if (subjectInput) subjectInput.value = subjectMap[formId];
+          if (descriptionInput) descriptionInput.value = descriptionMap[formId];
+        },
+        true
+      );
     }
   }
 });


### PR DESCRIPTION
## Summary
- hide subject and description fields for specific request forms
- auto-fill subject and description for new user and deactivation requests

## Testing
- `npx eslint src/forms.js`
- `yarn test`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68c006da4ca48320a7311bd2e4c79816