### PR TITLE
fix: reference ticket form id

### DIFF
--- a/templates/request_page.hbs
+++ b/templates/request_page.hbs
@@ -3,35 +3,35 @@
 
     <h1 class="request-title">
         {{request.subject}}
-        {{#if request.ticket_form_id}}
-            {{#is request.ticket_form_id settings.request_form_1_id}}
+        {{#if request.ticket_form.id}}
+            {{#is request.ticket_form.id settings.request_form_1_id}}
                 <span class="status-label request-type-label" data-request-type="{{settings.request_form_1_name}}">{{settings.request_form_1_name}}</span>
             {{/is}}
-            {{#is request.ticket_form_id settings.request_form_2_id}}
+            {{#is request.ticket_form.id settings.request_form_2_id}}
                 <span class="status-label request-type-label" data-request-type="{{settings.request_form_2_name}}">{{settings.request_form_2_name}}</span>
             {{/is}}
-            {{#is request.ticket_form_id settings.request_form_3_id}}
+            {{#is request.ticket_form.id settings.request_form_3_id}}
                 <span class="status-label request-type-label" data-request-type="{{settings.request_form_3_name}}">{{settings.request_form_3_name}}</span>
             {{/is}}
-            {{#is request.ticket_form_id settings.request_form_4_id}}
+            {{#is request.ticket_form.id settings.request_form_4_id}}
                 <span class="status-label request-type-label" data-request-type="{{settings.request_form_4_name}}">{{settings.request_form_4_name}}</span>
             {{/is}}
-            {{#is request.ticket_form_id settings.request_form_5_id}}
+            {{#is request.ticket_form.id settings.request_form_5_id}}
                 <span class="status-label request-type-label" data-request-type="{{settings.request_form_5_name}}">{{settings.request_form_5_name}}</span>
             {{/is}}
-            {{#is request.ticket_form_id settings.request_form_6_id}}
+            {{#is request.ticket_form.id settings.request_form_6_id}}
                 <span class="status-label request-type-label" data-request-type="{{settings.request_form_6_name}}">{{settings.request_form_6_name}}</span>
             {{/is}}
-            {{#is request.ticket_form_id settings.request_form_7_id}}
+            {{#is request.ticket_form.id settings.request_form_7_id}}
                 <span class="status-label request-type-label" data-request-type="{{settings.request_form_7_name}}">{{settings.request_form_7_name}}</span>
             {{/is}}
-            {{#is request.ticket_form_id settings.request_form_8_id}}
+            {{#is request.ticket_form.id settings.request_form_8_id}}
                 <span class="status-label request-type-label" data-request-type="{{settings.request_form_8_name}}">{{settings.request_form_8_name}}</span>
             {{/is}}
-            {{#is request.ticket_form_id settings.request_form_9_id}}
+            {{#is request.ticket_form.id settings.request_form_9_id}}
                 <span class="status-label request-type-label" data-request-type="{{settings.request_form_9_name}}">{{settings.request_form_9_name}}</span>
             {{/is}}
-            {{#is request.ticket_form_id settings.request_form_10_id}}
+            {{#is request.ticket_form.id settings.request_form_10_id}}
                 <span class="status-label request-type-label" data-request-type="{{settings.request_form_10_name}}">{{settings.request_form_10_name}}</span>
             {{/is}}
         {{/if}}
@@ -230,37 +230,37 @@
                     <dt>{{t 'id'}}</dt>
                     <dd>#{{request.id}}</dd>
 
-                    {{#if request.ticket_form_id}}
+                    {{#if request.ticket_form.id}}
                         <dt>Request type</dt>
                         <dd>
-                            {{#is request.ticket_form_id settings.request_form_1_id}}
+                            {{#is request.ticket_form.id settings.request_form_1_id}}
                                 <span class="status-label request-type-label" data-request-type="{{settings.request_form_1_name}}">{{settings.request_form_1_name}}</span>
                             {{/is}}
-                            {{#is request.ticket_form_id settings.request_form_2_id}}
+                            {{#is request.ticket_form.id settings.request_form_2_id}}
                                 <span class="status-label request-type-label" data-request-type="{{settings.request_form_2_name}}">{{settings.request_form_2_name}}</span>
                             {{/is}}
-                            {{#is request.ticket_form_id settings.request_form_3_id}}
+                            {{#is request.ticket_form.id settings.request_form_3_id}}
                                 <span class="status-label request-type-label" data-request-type="{{settings.request_form_3_name}}">{{settings.request_form_3_name}}</span>
                             {{/is}}
-                            {{#is request.ticket_form_id settings.request_form_4_id}}
+                            {{#is request.ticket_form.id settings.request_form_4_id}}
                                 <span class="status-label request-type-label" data-request-type="{{settings.request_form_4_name}}">{{settings.request_form_4_name}}</span>
                             {{/is}}
-                            {{#is request.ticket_form_id settings.request_form_5_id}}
+                            {{#is request.ticket_form.id settings.request_form_5_id}}
                                 <span class="status-label request-type-label" data-request-type="{{settings.request_form_5_name}}">{{settings.request_form_5_name}}</span>
                             {{/is}}
-                            {{#is request.ticket_form_id settings.request_form_6_id}}
+                            {{#is request.ticket_form.id settings.request_form_6_id}}
                                 <span class="status-label request-type-label" data-request-type="{{settings.request_form_6_name}}">{{settings.request_form_6_name}}</span>
                             {{/is}}
-                            {{#is request.ticket_form_id settings.request_form_7_id}}
+                            {{#is request.ticket_form.id settings.request_form_7_id}}
                                 <span class="status-label request-type-label" data-request-type="{{settings.request_form_7_name}}">{{settings.request_form_7_name}}</span>
                             {{/is}}
-                            {{#is request.ticket_form_id settings.request_form_8_id}}
+                            {{#is request.ticket_form.id settings.request_form_8_id}}
                                 <span class="status-label request-type-label" data-request-type="{{settings.request_form_8_name}}">{{settings.request_form_8_name}}</span>
                             {{/is}}
-                            {{#is request.ticket_form_id settings.request_form_9_id}}
+                            {{#is request.ticket_form.id settings.request_form_9_id}}
                                 <span class="status-label request-type-label" data-request-type="{{settings.request_form_9_name}}">{{settings.request_form_9_name}}</span>
                             {{/is}}
-                            {{#is request.ticket_form_id settings.request_form_10_id}}
+                            {{#is request.ticket_form.id settings.request_form_10_id}}
                                 <span class="status-label request-type-label" data-request-type="{{settings.request_form_10_name}}">{{settings.request_form_10_name}}</span>
                             {{/is}}
                         </dd>

--- a/templates/requests_page.hbs
+++ b/templates/requests_page.hbs
@@ -103,17 +103,17 @@
           <tbody>
             {{#each requests}}
               <tr {{#is status 'closed'}} class="request-closed" {{/is}}
-                  {{#if ticket_form_id}}
-                    {{#is ticket_form_id settings.request_form_1_id}}data-request-type="{{settings.request_form_1_name}}"{{/is}}
-                    {{#is ticket_form_id settings.request_form_2_id}}data-request-type="{{settings.request_form_2_name}}"{{/is}}
-                    {{#is ticket_form_id settings.request_form_3_id}}data-request-type="{{settings.request_form_3_name}}"{{/is}}
-                    {{#is ticket_form_id settings.request_form_4_id}}data-request-type="{{settings.request_form_4_name}}"{{/is}}
-                    {{#is ticket_form_id settings.request_form_5_id}}data-request-type="{{settings.request_form_5_name}}"{{/is}}
-                    {{#is ticket_form_id settings.request_form_6_id}}data-request-type="{{settings.request_form_6_name}}"{{/is}}
-                    {{#is ticket_form_id settings.request_form_7_id}}data-request-type="{{settings.request_form_7_name}}"{{/is}}
-                    {{#is ticket_form_id settings.request_form_8_id}}data-request-type="{{settings.request_form_8_name}}"{{/is}}
-                    {{#is ticket_form_id settings.request_form_9_id}}data-request-type="{{settings.request_form_9_name}}"{{/is}}
-                    {{#is ticket_form_id settings.request_form_10_id}}data-request-type="{{settings.request_form_10_name}}"{{/is}}
+                  {{#if ticket_form.id}}
+                    {{#is ticket_form.id ../settings.request_form_1_id}}data-request-type="{{../settings.request_form_1_name}}"{{/is}}
+                    {{#is ticket_form.id ../settings.request_form_2_id}}data-request-type="{{../settings.request_form_2_name}}"{{/is}}
+                    {{#is ticket_form.id ../settings.request_form_3_id}}data-request-type="{{../settings.request_form_3_name}}"{{/is}}
+                    {{#is ticket_form.id ../settings.request_form_4_id}}data-request-type="{{../settings.request_form_4_name}}"{{/is}}
+                    {{#is ticket_form.id ../settings.request_form_5_id}}data-request-type="{{../settings.request_form_5_name}}"{{/is}}
+                    {{#is ticket_form.id ../settings.request_form_6_id}}data-request-type="{{../settings.request_form_6_name}}"{{/is}}
+                    {{#is ticket_form.id ../settings.request_form_7_id}}data-request-type="{{../settings.request_form_7_name}}"{{/is}}
+                    {{#is ticket_form.id ../settings.request_form_8_id}}data-request-type="{{../settings.request_form_8_name}}"{{/is}}
+                    {{#is ticket_form.id ../settings.request_form_9_id}}data-request-type="{{../settings.request_form_9_name}}"{{/is}}
+                    {{#is ticket_form.id ../settings.request_form_10_id}}data-request-type="{{../settings.request_form_10_name}}"{{/is}}
                   {{/if}}>
                 <td class="request-info requests-table-info">
                   <a href="{{url}}" class="striped-list-title" title="{{subject}}">
@@ -123,36 +123,36 @@
                       {{excerpt description characters=50}}
                     {{/if}}
                   </a>
-                  {{#if ticket_form_id}}
-                    {{#is ticket_form_id settings.request_form_1_id}}
-                      <span class="status-label request-type-label" data-request-type="{{settings.request_form_1_name}}">{{settings.request_form_1_name}}</span>
+                  {{#if ticket_form.id}}
+                    {{#is ticket_form.id ../settings.request_form_1_id}}
+                      <span class="status-label request-type-label" data-request-type="{{../settings.request_form_1_name}}">{{../settings.request_form_1_name}}</span>
                     {{/is}}
-                    {{#is ticket_form_id settings.request_form_2_id}}
-                      <span class="status-label request-type-label" data-request-type="{{settings.request_form_2_name}}">{{settings.request_form_2_name}}</span>
+                    {{#is ticket_form.id ../settings.request_form_2_id}}
+                      <span class="status-label request-type-label" data-request-type="{{../settings.request_form_2_name}}">{{../settings.request_form_2_name}}</span>
                     {{/is}}
-                    {{#is ticket_form_id settings.request_form_3_id}}
-                      <span class="status-label request-type-label" data-request-type="{{settings.request_form_3_name}}">{{settings.request_form_3_name}}</span>
+                    {{#is ticket_form.id ../settings.request_form_3_id}}
+                      <span class="status-label request-type-label" data-request-type="{{../settings.request_form_3_name}}">{{../settings.request_form_3_name}}</span>
                     {{/is}}
-                    {{#is ticket_form_id settings.request_form_4_id}}
-                      <span class="status-label request-type-label" data-request-type="{{settings.request_form_4_name}}">{{settings.request_form_4_name}}</span>
+                    {{#is ticket_form.id ../settings.request_form_4_id}}
+                      <span class="status-label request-type-label" data-request-type="{{../settings.request_form_4_name}}">{{../settings.request_form_4_name}}</span>
                     {{/is}}
-                    {{#is ticket_form_id settings.request_form_5_id}}
-                      <span class="status-label request-type-label" data-request-type="{{settings.request_form_5_name}}">{{settings.request_form_5_name}}</span>
+                    {{#is ticket_form.id ../settings.request_form_5_id}}
+                      <span class="status-label request-type-label" data-request-type="{{../settings.request_form_5_name}}">{{../settings.request_form_5_name}}</span>
                     {{/is}}
-                    {{#is ticket_form_id settings.request_form_6_id}}
-                      <span class="status-label request-type-label" data-request-type="{{settings.request_form_6_name}}">{{settings.request_form_6_name}}</span>
+                    {{#is ticket_form.id ../settings.request_form_6_id}}
+                      <span class="status-label request-type-label" data-request-type="{{../settings.request_form_6_name}}">{{../settings.request_form_6_name}}</span>
                     {{/is}}
-                    {{#is ticket_form_id settings.request_form_7_id}}
-                      <span class="status-label request-type-label" data-request-type="{{settings.request_form_7_name}}">{{settings.request_form_7_name}}</span>
+                    {{#is ticket_form.id ../settings.request_form_7_id}}
+                      <span class="status-label request-type-label" data-request-type="{{../settings.request_form_7_name}}">{{../settings.request_form_7_name}}</span>
                     {{/is}}
-                    {{#is ticket_form_id settings.request_form_8_id}}
-                      <span class="status-label request-type-label" data-request-type="{{settings.request_form_8_name}}">{{settings.request_form_8_name}}</span>
+                    {{#is ticket_form.id ../settings.request_form_8_id}}
+                      <span class="status-label request-type-label" data-request-type="{{../settings.request_form_8_name}}">{{../settings.request_form_8_name}}</span>
                     {{/is}}
-                    {{#is ticket_form_id settings.request_form_9_id}}
-                      <span class="status-label request-type-label" data-request-type="{{settings.request_form_9_name}}">{{settings.request_form_9_name}}</span>
+                    {{#is ticket_form.id ../settings.request_form_9_id}}
+                      <span class="status-label request-type-label" data-request-type="{{../settings.request_form_9_name}}">{{../settings.request_form_9_name}}</span>
                     {{/is}}
-                    {{#is ticket_form_id settings.request_form_10_id}}
-                      <span class="status-label request-type-label" data-request-type="{{settings.request_form_10_name}}">{{settings.request_form_10_name}}</span>
+                    {{#is ticket_form.id ../settings.request_form_10_id}}
+                      <span class="status-label request-type-label" data-request-type="{{../settings.request_form_10_name}}">{{../settings.request_form_10_name}}</span>
                     {{/is}}
                   {{/if}}
 
@@ -163,36 +163,36 @@
                     <span class="status-label status-label-request status-label-{{status}}" title="{{status_description}}">
                       {{status_name}}
                     </span>
-                    {{#if ticket_form_id}}
-                      {{#is ticket_form_id settings.request_form_1_id}}
-                        <span class="status-label request-type-label" data-request-type="{{settings.request_form_1_name}}">{{settings.request_form_1_name}}</span>
+                    {{#if ticket_form.id}}
+                      {{#is ticket_form.id ../settings.request_form_1_id}}
+                        <span class="status-label request-type-label" data-request-type="{{../settings.request_form_1_name}}">{{../settings.request_form_1_name}}</span>
                       {{/is}}
-                      {{#is ticket_form_id settings.request_form_2_id}}
-                        <span class="status-label request-type-label" data-request-type="{{settings.request_form_2_name}}">{{settings.request_form_2_name}}</span>
+                      {{#is ticket_form.id ../settings.request_form_2_id}}
+                        <span class="status-label request-type-label" data-request-type="{{../settings.request_form_2_name}}">{{../settings.request_form_2_name}}</span>
                       {{/is}}
-                      {{#is ticket_form_id settings.request_form_3_id}}
-                        <span class="status-label request-type-label" data-request-type="{{settings.request_form_3_name}}">{{settings.request_form_3_name}}</span>
+                      {{#is ticket_form.id ../settings.request_form_3_id}}
+                        <span class="status-label request-type-label" data-request-type="{{../settings.request_form_3_name}}">{{../settings.request_form_3_name}}</span>
                       {{/is}}
-                      {{#is ticket_form_id settings.request_form_4_id}}
-                        <span class="status-label request-type-label" data-request-type="{{settings.request_form_4_name}}">{{settings.request_form_4_name}}</span>
+                      {{#is ticket_form.id ../settings.request_form_4_id}}
+                        <span class="status-label request-type-label" data-request-type="{{../settings.request_form_4_name}}">{{../settings.request_form_4_name}}</span>
                       {{/is}}
-                      {{#is ticket_form_id settings.request_form_5_id}}
-                        <span class="status-label request-type-label" data-request-type="{{settings.request_form_5_name}}">{{settings.request_form_5_name}}</span>
+                      {{#is ticket_form.id ../settings.request_form_5_id}}
+                        <span class="status-label request-type-label" data-request-type="{{../settings.request_form_5_name}}">{{../settings.request_form_5_name}}</span>
                       {{/is}}
-                      {{#is ticket_form_id settings.request_form_6_id}}
-                        <span class="status-label request-type-label" data-request-type="{{settings.request_form_6_name}}">{{settings.request_form_6_name}}</span>
+                      {{#is ticket_form.id ../settings.request_form_6_id}}
+                        <span class="status-label request-type-label" data-request-type="{{../settings.request_form_6_name}}">{{../settings.request_form_6_name}}</span>
                       {{/is}}
-                      {{#is ticket_form_id settings.request_form_7_id}}
-                        <span class="status-label request-type-label" data-request-type="{{settings.request_form_7_name}}">{{settings.request_form_7_name}}</span>
+                      {{#is ticket_form.id ../settings.request_form_7_id}}
+                        <span class="status-label request-type-label" data-request-type="{{../settings.request_form_7_name}}">{{../settings.request_form_7_name}}</span>
                       {{/is}}
-                      {{#is ticket_form_id settings.request_form_8_id}}
-                        <span class="status-label request-type-label" data-request-type="{{settings.request_form_8_name}}">{{settings.request_form_8_name}}</span>
+                      {{#is ticket_form.id ../settings.request_form_8_id}}
+                        <span class="status-label request-type-label" data-request-type="{{../settings.request_form_8_name}}">{{../settings.request_form_8_name}}</span>
                       {{/is}}
-                      {{#is ticket_form_id settings.request_form_9_id}}
-                        <span class="status-label request-type-label" data-request-type="{{settings.request_form_9_name}}">{{settings.request_form_9_name}}</span>
+                      {{#is ticket_form.id ../settings.request_form_9_id}}
+                        <span class="status-label request-type-label" data-request-type="{{../settings.request_form_9_name}}">{{../settings.request_form_9_name}}</span>
                       {{/is}}
-                      {{#is ticket_form_id settings.request_form_10_id}}
-                        <span class="status-label request-type-label" data-request-type="{{settings.request_form_10_name}}">{{settings.request_form_10_name}}</span>
+                      {{#is ticket_form.id ../settings.request_form_10_id}}
+                        <span class="status-label request-type-label" data-request-type="{{../settings.request_form_10_name}}">{{../settings.request_form_10_name}}</span>
                       {{/is}}
                     {{/if}}
                   </div>


### PR DESCRIPTION
## Summary
- avoid unsupported `ticket_form_id` lookups in request templates
- access ticket form id and settings safely

## Testing
- `yarn test`
- `yarn eslint` *(fails: prettier/prettier errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c03fc4aeec83208659631a7ed24007