### PR TITLE
fix: expand header width on desktop

### DIFF
--- a/styles/_header.scss
+++ b/styles/_header.scss
@@ -3,6 +3,12 @@ $header-height: 71px;
 
 .header {
   @include max-width-container;
+  @include desktop {
+    margin: 0;
+    max-width: none;
+    padding: 0 5%;
+    width: 100%;
+  }
   position: relative;
   align-items: center;
   display: flex;


### PR DESCRIPTION
## Summary
- allow the header to span the full page width on desktop by clearing its max-width and centering margin while preserving padding

## Testing
- yarn test

------
https://chatgpt.com/codex/tasks/task_e_68c94836b4308320a55f0493a49223b3